### PR TITLE
fix(#26): address code review findings

### DIFF
--- a/src/components/GameScreen.jsx
+++ b/src/components/GameScreen.jsx
@@ -107,12 +107,12 @@ function GameScreen({ onGameEnd, updateProgress = null, initialProgress = null }
 
         {/* Learning Aid - shown when child is struggling */}
         <LearningAid
+          key={totalProblems}
           isStruggling={isStruggling}
           currentLevel={2}
           num1={currentProblem.num1}
           num2={currentProblem.num2}
           operator={currentProblem.operator}
-          problemKey={totalProblems}
         />
 
         {/* Answer Buttons - 2x2 Grid */}

--- a/src/components/aids/LearningAid.jsx
+++ b/src/components/aids/LearningAid.jsx
@@ -12,18 +12,17 @@
  *
  * Dismiss behaviour:
  *   - "I got it!" button hides the aid for the current problem
- *   - Auto-resets when `problemKey` changes (new problem)
+ *   - Auto-resets when the parent supplies a new React `key` (new problem)
  *
  * @param {Object}         props
  * @param {boolean}        props.isStruggling  Whether the confidence engine signals struggle
  * @param {number}         props.currentLevel  Current difficulty level (1-13)
  * @param {number}         props.num1          Left operand
  * @param {number}         props.num2          Right operand
- * @param {string}         props.operator      '+', '-', '*', or '/'
- * @param {string|number}  props.problemKey    Unique key to detect new problem
+ * @param {'+' | '-' | '*' | '/'}  props.operator  Arithmetic operator
  */
 
-import { useState, useEffect } from 'react'
+import { useState } from 'react'
 import PropTypes from 'prop-types'
 import DotCounter from './DotCounter'
 import NumberLine from './NumberLine'
@@ -50,13 +49,8 @@ function selectAid(level) {
   return null
 }
 
-function LearningAid({ isStruggling, currentLevel, num1, num2, operator, problemKey }) {
+function LearningAid({ isStruggling, currentLevel, num1, num2, operator }) {
   const [dismissed, setDismissed] = useState(false)
-
-  // Auto-reset dismissed state when the problem changes
-  useEffect(() => {
-    setDismissed(false)
-  }, [problemKey])
 
   // Nothing to show if not struggling or dismissed
   if (!isStruggling || dismissed) {
@@ -107,8 +101,7 @@ LearningAid.propTypes = {
   currentLevel: PropTypes.number.isRequired,
   num1: PropTypes.number.isRequired,
   num2: PropTypes.number.isRequired,
-  operator: PropTypes.string.isRequired,
-  problemKey: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+  operator: PropTypes.oneOf(['+', '-', '*', '/']).isRequired,
 }
 
 export default LearningAid

--- a/src/components/aids/LearningAid.test.jsx
+++ b/src/components/aids/LearningAid.test.jsx
@@ -13,7 +13,6 @@ const defaultProps = {
   num1: 3,
   num2: 2,
   operator: '+',
-  problemKey: 1,
 }
 
 function renderAid(overrides = {}) {
@@ -116,28 +115,29 @@ describe('LearningAid', () => {
       expect(screen.queryByTestId('learning-aid-container')).toBeNull()
     })
 
-    it('auto-resets dismissed state when problemKey changes', () => {
-      const { rerender } = render(<LearningAid {...defaultProps} problemKey={1} />)
+    it('auto-resets dismissed state when key changes (remount)', () => {
+      const { unmount } = render(<LearningAid {...defaultProps} key={1} />)
 
       // Dismiss the aid
       fireEvent.click(screen.getByTestId('dismiss-aid-button'))
       expect(screen.queryByTestId('learning-aid-container')).toBeNull()
 
-      // Change problemKey to simulate a new problem
-      rerender(<LearningAid {...defaultProps} problemKey={2} />)
+      // Unmount and remount with a new key to simulate a new problem
+      unmount()
+      render(<LearningAid {...defaultProps} key={2} />)
 
       // Aid should reappear
       expect(screen.getByTestId('learning-aid-container')).toBeTruthy()
     })
 
-    it('stays dismissed if problemKey does not change', () => {
-      const { rerender } = render(<LearningAid {...defaultProps} problemKey={1} />)
+    it('stays dismissed within the same key (same mount)', () => {
+      const { rerender } = render(<LearningAid {...defaultProps} key={1} />)
 
       fireEvent.click(screen.getByTestId('dismiss-aid-button'))
       expect(screen.queryByTestId('learning-aid-container')).toBeNull()
 
-      // Rerender with same problemKey
-      rerender(<LearningAid {...defaultProps} problemKey={1} />)
+      // Rerender with same key — component stays mounted, dismissed persists
+      rerender(<LearningAid {...defaultProps} key={1} />)
       expect(screen.queryByTestId('learning-aid-container')).toBeNull()
     })
   })

--- a/src/components/aids/NumberLine.test.jsx
+++ b/src/components/aids/NumberLine.test.jsx
@@ -1,7 +1,7 @@
 /**
  * @vitest-environment happy-dom
  */
-import { describe, it, expect, vi, afterEach } from 'vitest'
+import { describe, it, expect, afterEach } from 'vitest'
 import { render, screen, cleanup } from '@testing-library/react'
 import NumberLine from './NumberLine'
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -66,7 +66,7 @@ export default {
           '100%': { opacity: '1', transform: 'translateY(0)' },
         },
         'arc-draw': {
-          '0%': { strokeDashoffset: '100%' },
+          '0%': { strokeDashoffset: '60' },
           '100%': { strokeDashoffset: '0' },
         },
       },


### PR DESCRIPTION
## Summary
- **Fix 1:** Replace `problemKey` prop + `useEffect` reset in `LearningAid` with React `key` prop on the parent (`GameScreen`). This is the idiomatic React pattern for resetting component state on identity change -- simpler and avoids a `setState`-inside-`useEffect` anti-pattern.
- **Fix 2:** Remove unused `vi` import from `NumberLine.test.jsx`.
- **Fix 3:** Change `arc-draw` keyframe `strokeDashoffset` from `'100%'` to `'60'` (numeric value matching the `stroke-dasharray` attribute set in `NumberLine.jsx`).
- **Fix 4:** Tighten `operator` PropTypes from `PropTypes.string` to `PropTypes.oneOf(['+', '-', '*', '/'])` for stricter validation.

Closes #26

## Test plan
- [x] `npm run lint` -- 0 errors
- [x] `npm test` -- 487 tests passing (16 files)
- [x] LearningAid dismiss-reset tests updated to use `key`-based remount pattern
- [x] No `problemKey` references remain in source or tests