### PR TITLE
feat(#78): level-up celebration screen

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,6 @@
 import { useState, useCallback } from 'react'
 import { useFirebase, useGameProgress } from './hooks'
-import { StartScreen, GameScreen, ResultScreen, ProfileSwitcher, CreateProfile } from './components'
+import { StartScreen, GameScreen, ResultScreen, LevelUpScreen, ProfileSwitcher, CreateProfile } from './components'
 import { useProfile } from './context/useProfile'
 
 /**
@@ -15,18 +15,24 @@ import { useProfile } from './context/useProfile'
  *                                      |
  *                                      v (onComplete)
  * [activeProfile set]             -> StartScreen -> GameScreen -> ResultScreen
- *                                      ^            |              |
- *                                      +------------+--------------+
+ *                                      ^            |    |         |
+ *                                      +------------+----+---------+
+ *                                                   |
+ *                                                   v (shouldLevelUp)
+ *                                               LevelUpScreen
+ *                                                   |
+ *                                                   v (Continue)
+ *                                               GameScreen (next level)
  *
  * Manages:
  * - Profile-gated entry: shows ProfileSwitcher or CreateProfile when no active profile
- * - Screen state ('start', 'game', 'result')
+ * - Screen state ('start', 'game', 'result', 'levelup')
  * - Firebase authentication
  * - Game progress persistence (keyed to activeProfile.firebaseUid)
  * - Session statistics between screens
  */
 function App() {
-  const { activeProfile, isLoading: profileLoading, clearActiveProfile, createAndActivate } = useProfile()
+  const { activeProfile, isLoading: profileLoading, clearActiveProfile, createAndActivate, updateProfile } = useProfile()
   const { user, loading: authLoading, error: authError } = useFirebase()
   const {
     progress,
@@ -46,6 +52,9 @@ function App() {
 
   // Whether to show CreateProfile wizard (when no active profile)
   const [showCreate, setShowCreate] = useState(false)
+
+  // Track which level was just completed (for LevelUpScreen)
+  const [completedLevel, setCompletedLevel] = useState(null)
 
   // Combine loading states
   const loading = profileLoading || authLoading || progressLoading
@@ -116,6 +125,25 @@ function App() {
   const handleCreateCancel = useCallback(() => {
     setShowCreate(false)
   }, [])
+
+  // Handle level-up detection from GameScreen
+  const handleLevelUp = useCallback((level) => {
+    setCompletedLevel(level)
+    setScreen('levelup')
+  }, [])
+
+  // Handle continue after level-up celebration
+  const handleContinueAfterLevelUp = useCallback(() => {
+    if (completedLevel !== null && activeProfile) {
+      const nextLevel = completedLevel + 1
+      // Max level guard: do not update profile beyond LEVELS.length (13)
+      if (nextLevel <= 13) {
+        updateProfile(activeProfile.id, { currentLevel: nextLevel })
+      }
+    }
+    setCompletedLevel(null)
+    setScreen('game')
+  }, [completedLevel, activeProfile, updateProfile])
 
   // Show loading state while authenticating or loading progress
   if (loading) {
@@ -200,6 +228,14 @@ function App() {
           updateProgress={updateProgress}
           initialProgress={progress}
           currentLevel={currentLevel}
+          onLevelUp={handleLevelUp}
+        />
+      )}
+
+      {screen === 'levelup' && completedLevel !== null && (
+        <LevelUpScreen
+          completedLevel={completedLevel}
+          onContinue={handleContinueAfterLevelUp}
         />
       )}
 

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -13,6 +13,7 @@ const mockProfileContext = {
   isLoading: false,
   clearActiveProfile: vi.fn(),
   createAndActivate: vi.fn(),
+  updateProfile: vi.fn(),
 }
 
 vi.mock('./context/useProfile', () => ({
@@ -43,7 +44,7 @@ vi.mock('./components', () => ({
       createElement('button', { 'data-testid': 'start-game', onClick: onStart }, 'Start'),
       createElement('button', { 'data-testid': 'switch-profile', onClick: onSwitchProfile }, 'Switch'),
     ),
-  GameScreen: ({ onGameEnd, currentLevel }) =>
+  GameScreen: ({ onGameEnd, currentLevel, onLevelUp }) =>
     createElement('div', { 'data-testid': 'game-screen', 'data-current-level': currentLevel },
       createElement('button', {
         'data-testid': 'end-game',
@@ -53,11 +54,19 @@ vi.mock('./components', () => ({
         'data-testid': 'exit-game',
         onClick: () => onGameEnd(null),
       }, 'Exit'),
+      createElement('button', {
+        'data-testid': 'trigger-level-up',
+        onClick: () => onLevelUp(currentLevel),
+      }, 'Level Up'),
     ),
   ResultScreen: ({ onPlayAgain, onExit }) =>
     createElement('div', { 'data-testid': 'result-screen' },
       createElement('button', { 'data-testid': 'play-again', onClick: onPlayAgain }, 'Play Again'),
       createElement('button', { 'data-testid': 'exit-result', onClick: onExit }, 'Exit'),
+    ),
+  LevelUpScreen: ({ completedLevel, onContinue }) =>
+    createElement('div', { 'data-testid': 'levelup-screen', 'data-completed-level': completedLevel },
+      createElement('button', { 'data-testid': 'continue-level-up', onClick: onContinue }, 'Continue'),
     ),
   ProfileSwitcher: ({ onCreateProfile }) =>
     createElement('div', { 'data-testid': 'profile-switcher' },
@@ -93,6 +102,7 @@ describe('App', () => {
     mockProfileContext.isLoading = false
     mockProfileContext.clearActiveProfile = vi.fn()
     mockProfileContext.createAndActivate = vi.fn()
+    mockProfileContext.updateProfile = vi.fn()
     mockFirebase.user = { uid: 'test-uid' }
     mockFirebase.loading = false
     mockFirebase.error = null
@@ -418,6 +428,113 @@ describe('App', () => {
 
       const gameScreen = screen.getByTestId('game-screen')
       expect(gameScreen.getAttribute('data-current-level')).toBe('13')
+    })
+  })
+
+  // ── Level-up flow ──────────────────────────────────────────────────
+
+  describe('level-up flow', () => {
+    it('transitions from game to levelup screen when onLevelUp is called', () => {
+      mockProfileContext.activeProfile = {
+        id: '1',
+        nickname: 'Dubi',
+        firebaseUid: 'uid-1',
+        currentLevel: 3,
+      }
+      render(<App />)
+
+      // Navigate to game
+      fireEvent.click(screen.getByTestId('start-game'))
+      expect(screen.getByTestId('game-screen')).toBeTruthy()
+
+      // Trigger level up
+      fireEvent.click(screen.getByTestId('trigger-level-up'))
+
+      // Should show level-up screen
+      expect(screen.getByTestId('levelup-screen')).toBeTruthy()
+      expect(screen.queryByTestId('game-screen')).toBeNull()
+    })
+
+    it('passes completedLevel to LevelUpScreen', () => {
+      mockProfileContext.activeProfile = {
+        id: '1',
+        nickname: 'Dubi',
+        firebaseUid: 'uid-1',
+        currentLevel: 5,
+      }
+      render(<App />)
+
+      fireEvent.click(screen.getByTestId('start-game'))
+      fireEvent.click(screen.getByTestId('trigger-level-up'))
+
+      const levelUpScreen = screen.getByTestId('levelup-screen')
+      expect(levelUpScreen.getAttribute('data-completed-level')).toBe('5')
+    })
+
+    it('transitions back to game screen when continue is clicked', () => {
+      mockProfileContext.activeProfile = {
+        id: '1',
+        nickname: 'Dubi',
+        firebaseUid: 'uid-1',
+        currentLevel: 3,
+      }
+      render(<App />)
+
+      // Navigate: start -> game -> levelup
+      fireEvent.click(screen.getByTestId('start-game'))
+      fireEvent.click(screen.getByTestId('trigger-level-up'))
+      expect(screen.getByTestId('levelup-screen')).toBeTruthy()
+
+      // Continue -> back to game
+      fireEvent.click(screen.getByTestId('continue-level-up'))
+      expect(screen.getByTestId('game-screen')).toBeTruthy()
+      expect(screen.queryByTestId('levelup-screen')).toBeNull()
+    })
+
+    it('calls updateProfile with currentLevel+1 when continue is clicked', () => {
+      mockProfileContext.activeProfile = {
+        id: '1',
+        nickname: 'Dubi',
+        firebaseUid: 'uid-1',
+        currentLevel: 3,
+      }
+      render(<App />)
+
+      fireEvent.click(screen.getByTestId('start-game'))
+      fireEvent.click(screen.getByTestId('trigger-level-up'))
+      fireEvent.click(screen.getByTestId('continue-level-up'))
+
+      expect(mockProfileContext.updateProfile).toHaveBeenCalledTimes(1)
+      expect(mockProfileContext.updateProfile).toHaveBeenCalledWith('1', { currentLevel: 4 })
+    })
+
+    it('does NOT call updateProfile with currentLevel 14 when at max level (13)', () => {
+      mockProfileContext.activeProfile = {
+        id: '1',
+        nickname: 'Dubi',
+        firebaseUid: 'uid-1',
+        currentLevel: 13,
+      }
+      render(<App />)
+
+      fireEvent.click(screen.getByTestId('start-game'))
+      fireEvent.click(screen.getByTestId('trigger-level-up'))
+      fireEvent.click(screen.getByTestId('continue-level-up'))
+
+      // Should NOT update profile to level 14
+      expect(mockProfileContext.updateProfile).not.toHaveBeenCalledWith('1', { currentLevel: 14 })
+    })
+
+    it('does not show levelup screen on initial render', () => {
+      mockProfileContext.activeProfile = {
+        id: '1',
+        nickname: 'Dubi',
+        firebaseUid: 'uid-1',
+        currentLevel: 1,
+      }
+      render(<App />)
+
+      expect(screen.queryByTestId('levelup-screen')).toBeNull()
     })
   })
 })

--- a/src/components/GameScreen.jsx
+++ b/src/components/GameScreen.jsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react'
 import PropTypes from 'prop-types'
 import { Problem, AnswerButtons, ScoreDisplay, Feedback } from './index'
 import { LearningAid } from './aids'
@@ -21,8 +22,9 @@ import { useGameState } from '../hooks'
  * @param {function} updateProgress - Optional callback for Firestore persistence
  * @param {object} initialProgress - Optional initial progress from Firestore
  * @param {number} currentLevel - Current difficulty level (1-13, default 1)
+ * @param {function} onLevelUp - Optional callback when confidence engine signals level-up
  */
-function GameScreen({ onGameEnd, updateProgress = null, initialProgress = null, currentLevel = 1 }) {
+function GameScreen({ onGameEnd, updateProgress = null, initialProgress = null, currentLevel = 1, onLevelUp }) {
   const {
     currentProblem,
     score,
@@ -37,7 +39,17 @@ function GameScreen({ onGameEnd, updateProgress = null, initialProgress = null, 
     correctAnswers,
     accuracy,
     isStruggling,
+    shouldLevelUp,
   } = useGameState({ currentLevel, updateProgress, initialProgress })
+
+  // Detect level-up: when confidence engine signals shouldLevelUp AND feedback
+  // animation has cleared, notify the parent (App) to transition to LevelUpScreen.
+  // The parent unmounts GameScreen, so no race condition with auto-advance.
+  useEffect(() => {
+    if (shouldLevelUp && !showFeedback && onLevelUp) {
+      onLevelUp(currentLevel)
+    }
+  }, [shouldLevelUp, showFeedback, onLevelUp, currentLevel])
 
   // Start game automatically if not playing
   // This handles the initial mount
@@ -147,6 +159,7 @@ GameScreen.propTypes = {
     correctAnswers: PropTypes.number,
   }),
   currentLevel: PropTypes.number,
+  onLevelUp: PropTypes.func,
 }
 
 export default GameScreen

--- a/src/components/GameScreen.test.jsx
+++ b/src/components/GameScreen.test.jsx
@@ -1,0 +1,171 @@
+/**
+ * @vitest-environment happy-dom
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, act, cleanup } from '@testing-library/react'
+import { createElement } from 'react'
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+
+// Mock useGameState hook with controllable state
+const mockGameState = {
+  currentProblem: { num1: 3, num2: 2, operator: '+', correctAnswer: 5, options: [3, 4, 5, 6] },
+  score: 0,
+  streak: 0,
+  bestStreak: 0,
+  showFeedback: false,
+  isCorrect: false,
+  handleAnswer: vi.fn(),
+  startGame: vi.fn(),
+  isPlaying: true,
+  totalProblems: 0,
+  correctAnswers: 0,
+  accuracy: 0,
+  isStruggling: false,
+  shouldLevelUp: false,
+}
+
+vi.mock('../hooks', () => ({
+  useGameState: () => mockGameState,
+}))
+
+// Mock child components (Problem, AnswerButtons, ScoreDisplay, Feedback)
+vi.mock('./index', () => ({
+  Problem: ({ num1, num2, operator }) =>
+    createElement('div', { 'data-testid': 'problem' }, `${num1} ${operator} ${num2}`),
+  AnswerButtons: ({ options, onAnswer, disabled }) =>
+    createElement('div', { 'data-testid': 'answer-buttons' },
+      options.map((opt) =>
+        createElement('button', {
+          key: opt,
+          'data-testid': `answer-${opt}`,
+          onClick: () => onAnswer(opt),
+          disabled,
+        }, opt)
+      )
+    ),
+  ScoreDisplay: ({ score, streak }) =>
+    createElement('div', { 'data-testid': 'score-display' }, `Score: ${score} Streak: ${streak}`),
+  Feedback: ({ isCorrect }) =>
+    createElement('div', { 'data-testid': 'feedback' }, isCorrect ? 'Correct!' : 'Wrong!'),
+}))
+
+// Mock LearningAid
+vi.mock('./aids', () => ({
+  LearningAid: () => createElement('div', { 'data-testid': 'learning-aid' }),
+}))
+
+// Import after mocks
+const { default: GameScreen } = await import('./GameScreen')
+
+describe('GameScreen', () => {
+  const defaultProps = {
+    onGameEnd: vi.fn(),
+    updateProgress: vi.fn(),
+    initialProgress: null,
+    currentLevel: 1,
+    onLevelUp: vi.fn(),
+  }
+
+  beforeEach(() => {
+    cleanup()
+    vi.clearAllMocks()
+    // Reset mock state to defaults
+    mockGameState.currentProblem = { num1: 3, num2: 2, operator: '+', correctAnswer: 5, options: [3, 4, 5, 6] }
+    mockGameState.score = 0
+    mockGameState.streak = 0
+    mockGameState.bestStreak = 0
+    mockGameState.showFeedback = false
+    mockGameState.isCorrect = false
+    mockGameState.isPlaying = true
+    mockGameState.totalProblems = 0
+    mockGameState.correctAnswers = 0
+    mockGameState.accuracy = 0
+    mockGameState.isStruggling = false
+    mockGameState.shouldLevelUp = false
+  })
+
+  // ── Basic rendering ────────────────────────────────────────────────
+
+  describe('basic rendering', () => {
+    it('renders the game screen with problem and answers', () => {
+      render(<GameScreen {...defaultProps} />)
+      expect(screen.getByTestId('problem')).toBeTruthy()
+      expect(screen.getByTestId('answer-buttons')).toBeTruthy()
+    })
+
+    it('renders exit button', () => {
+      render(<GameScreen {...defaultProps} />)
+      expect(screen.getByLabelText('Exit game and return to start screen')).toBeTruthy()
+    })
+
+    it('calls startGame when not playing', () => {
+      mockGameState.isPlaying = false
+      render(<GameScreen {...defaultProps} />)
+      expect(mockGameState.startGame).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  // ── shouldLevelUp detection ────────────────────────────────────────
+
+  describe('shouldLevelUp detection', () => {
+    it('calls onLevelUp when shouldLevelUp is true and showFeedback is false', () => {
+      mockGameState.shouldLevelUp = true
+      mockGameState.showFeedback = false
+
+      render(<GameScreen {...defaultProps} currentLevel={3} />)
+
+      expect(defaultProps.onLevelUp).toHaveBeenCalledTimes(1)
+      expect(defaultProps.onLevelUp).toHaveBeenCalledWith(3)
+    })
+
+    it('does NOT call onLevelUp when shouldLevelUp is false', () => {
+      mockGameState.shouldLevelUp = false
+      mockGameState.showFeedback = false
+
+      render(<GameScreen {...defaultProps} currentLevel={3} />)
+
+      expect(defaultProps.onLevelUp).not.toHaveBeenCalled()
+    })
+
+    it('does NOT call onLevelUp when showFeedback is true (waiting for feedback to clear)', () => {
+      mockGameState.shouldLevelUp = true
+      mockGameState.showFeedback = true
+
+      render(<GameScreen {...defaultProps} currentLevel={3} />)
+
+      expect(defaultProps.onLevelUp).not.toHaveBeenCalled()
+    })
+
+    it('does NOT call onLevelUp when onLevelUp prop is not provided', () => {
+      mockGameState.shouldLevelUp = true
+      mockGameState.showFeedback = false
+
+      // Should not throw
+      render(<GameScreen {...defaultProps} onLevelUp={undefined} />)
+    })
+  })
+
+  // ── Exit (onGameEnd) ──────────────────────────────────────────────
+
+  describe('exit button', () => {
+    it('calls onGameEnd with session stats when exit is clicked', () => {
+      mockGameState.score = 50
+      mockGameState.bestStreak = 3
+      mockGameState.totalProblems = 10
+      mockGameState.correctAnswers = 7
+      mockGameState.accuracy = 70
+
+      render(<GameScreen {...defaultProps} />)
+      fireEvent.click(screen.getByLabelText('Exit game and return to start screen'))
+
+      expect(defaultProps.onGameEnd).toHaveBeenCalledWith({
+        score: 50,
+        streak: 3,
+        totalProblems: 10,
+        correctAnswers: 7,
+        accuracy: 70,
+      })
+    })
+  })
+})

--- a/src/components/LevelUpScreen.jsx
+++ b/src/components/LevelUpScreen.jsx
@@ -1,0 +1,126 @@
+/**
+ * LevelUpScreen -- Celebration screen when player completes a level
+ *
+ * Shown as a full-screen state in App.jsx's state machine (peer to
+ * 'start', 'game', 'result'). Displays celebration animation,
+ * completed level info, and a CTA to continue to the next level.
+ *
+ * Visual MVP: emoji hero + CSS confetti particles, no audio.
+ *
+ * @param {Object}   props
+ * @param {number}   props.completedLevel  The level just completed (1-13)
+ * @param {Function} props.onContinue      Callback when user clicks Continue
+ */
+
+import PropTypes from 'prop-types'
+import { LEVELS } from '../config/levels'
+
+/** Number of confetti particles to render */
+const CONFETTI_COUNT = 12
+
+/** Confetti color palette */
+const CONFETTI_COLORS = [
+  'bg-yellow-400',
+  'bg-pink-400',
+  'bg-blue-400',
+  'bg-green-400',
+  'bg-purple-400',
+  'bg-red-400',
+]
+
+function LevelUpScreen({ completedLevel, onContinue }) {
+  const completedLevelConfig = LEVELS[completedLevel - 1]
+  const isMaxLevel = completedLevel >= LEVELS.length
+  const nextLevelConfig = isMaxLevel ? null : LEVELS[completedLevel]
+
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-sonic-blue to-blue-900 flex flex-col items-center justify-center p-4 relative overflow-hidden">
+      {/* Confetti particles (pure CSS animation) */}
+      {Array.from({ length: CONFETTI_COUNT }).map((_, i) => (
+        <span
+          key={i}
+          data-testid="confetti-particle"
+          className={`
+            absolute w-3 h-3 rounded-full
+            ${CONFETTI_COLORS[i % CONFETTI_COLORS.length]}
+            animate-confetti-fall motion-reduce:hidden
+            opacity-80
+          `}
+          style={{
+            left: `${8 + (i * 84) / CONFETTI_COUNT}%`,
+            animationDelay: `${i * 0.15}s`,
+            animationDuration: `${1.5 + (i % 3) * 0.5}s`,
+          }}
+          aria-hidden="true"
+        />
+      ))}
+
+      {/* Hero emoji with bounce animation */}
+      <div
+        data-testid="hero-emoji"
+        className="text-7xl md:text-8xl mb-4 animate-bounce-hero motion-reduce:animate-none"
+        aria-hidden="true"
+      >
+        🚀
+      </div>
+
+      {/* Screen-reader announcement */}
+      <div role="status" aria-live="polite" className="sr-only">
+        Level complete! You finished {completedLevelConfig?.name}.
+        {nextLevelConfig ? ` Next up: ${nextLevelConfig.name}.` : ' You have completed all levels!'}
+      </div>
+
+      {/* Main heading */}
+      <h1 className="text-4xl md:text-6xl font-game text-sonic-gold drop-shadow-lg text-center mb-2">
+        Level Complete!
+      </h1>
+
+      {/* Completed level name */}
+      <p className="text-xl md:text-2xl font-game text-white text-center mb-1">
+        {completedLevelConfig?.name}
+      </p>
+
+      {/* Next level subheading */}
+      {nextLevelConfig && (
+        <p className="text-lg md:text-xl font-game text-yellow-200 text-center mb-8">
+          Next: {nextLevelConfig.name}
+        </p>
+      )}
+
+      {/* Spacer when no next level */}
+      {!nextLevelConfig && <div className="mb-8" />}
+
+      {/* Continue CTA button */}
+      <button
+        onClick={onContinue}
+        className="
+          min-h-[44px] px-8 py-4
+          bg-sonic-gold text-sonic-blue font-game text-xl md:text-2xl
+          rounded-full shadow-lg
+          transform transition-all duration-200
+          hover:bg-yellow-400 hover:scale-105 active:scale-95
+          focus:outline-none focus:ring-2 focus:ring-yellow-300
+        "
+        aria-label={
+          isMaxLevel
+            ? 'Continue playing'
+            : `Continue to Level ${completedLevel + 1}`
+        }
+      >
+        {isMaxLevel
+          ? 'Keep Playing!'
+          : `Continue to Level ${completedLevel + 1}!`}
+      </button>
+
+      {/* Audio placeholder for future audio hook */}
+      <span data-testid="audio-placeholder" aria-hidden="true" />
+    </div>
+  )
+}
+
+LevelUpScreen.propTypes = {
+  completedLevel: PropTypes.number.isRequired,
+  onContinue: PropTypes.func.isRequired,
+}
+
+export default LevelUpScreen

--- a/src/components/LevelUpScreen.test.jsx
+++ b/src/components/LevelUpScreen.test.jsx
@@ -1,0 +1,182 @@
+/**
+ * @vitest-environment happy-dom
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+
+// Mock levels config
+vi.mock('../config/levels', () => ({
+  LEVELS: [
+    { id: 1, name: 'First Steps' },
+    { id: 2, name: 'Addition Hero' },
+    { id: 3, name: 'Minus Magic' },
+    { id: 4, name: 'Mixed Warrior' },
+    { id: 5, name: 'Cross the 10' },
+    { id: 6, name: 'Subtract 20' },
+    { id: 7, name: 'Mixed 20' },
+    { id: 8, name: 'Tens Master' },
+    { id: 9, name: 'Century Runner' },
+    { id: 10, name: 'Speed of 2s' },
+    { id: 11, name: 'Times Tables' },
+    { id: 12, name: 'Division Quest' },
+    { id: 13, name: 'Math Champion' },
+  ],
+}))
+
+// Import after mocks
+const { default: LevelUpScreen } = await import('./LevelUpScreen')
+
+describe('LevelUpScreen', () => {
+  const mockOnContinue = vi.fn()
+
+  beforeEach(() => {
+    cleanup()
+    vi.clearAllMocks()
+  })
+
+  // ── Rendering ──────────────────────────────────────────────────────
+
+  describe('rendering', () => {
+    it('renders the "Level Complete!" heading', () => {
+      render(<LevelUpScreen completedLevel={1} onContinue={mockOnContinue} />)
+      expect(screen.getByRole('heading', { level: 1 })).toBeTruthy()
+      expect(screen.getByText('Level Complete!')).toBeTruthy()
+    })
+
+    it('displays the completed level name', () => {
+      render(<LevelUpScreen completedLevel={3} onContinue={mockOnContinue} />)
+      expect(screen.getAllByText(/Minus Magic/).length).toBeGreaterThanOrEqual(1)
+    })
+
+    it('displays the next level name for mid-range levels', () => {
+      render(<LevelUpScreen completedLevel={5} onContinue={mockOnContinue} />)
+      expect(screen.getAllByText(/Subtract 20/).length).toBeGreaterThanOrEqual(1)
+    })
+
+    it('renders hero emoji with bounce animation', () => {
+      render(<LevelUpScreen completedLevel={1} onContinue={mockOnContinue} />)
+      const hero = screen.getByTestId('hero-emoji')
+      expect(hero).toBeTruthy()
+      expect(hero.className).toContain('animate-bounce-hero')
+    })
+
+    it('renders confetti particles', () => {
+      render(<LevelUpScreen completedLevel={1} onContinue={mockOnContinue} />)
+      const particles = screen.getAllByTestId('confetti-particle')
+      expect(particles.length).toBeGreaterThanOrEqual(8)
+    })
+
+    it('renders audio placeholder for future audio hook', () => {
+      render(<LevelUpScreen completedLevel={1} onContinue={mockOnContinue} />)
+      expect(screen.getByTestId('audio-placeholder')).toBeTruthy()
+    })
+  })
+
+  // ── Continue button ────────────────────────────────────────────────
+
+  describe('continue button', () => {
+    it('renders the continue button with next level number', () => {
+      render(<LevelUpScreen completedLevel={4} onContinue={mockOnContinue} />)
+      expect(screen.getByRole('button', { name: /Continue to Level 5/i })).toBeTruthy()
+    })
+
+    it('calls onContinue when continue button is clicked', () => {
+      render(<LevelUpScreen completedLevel={2} onContinue={mockOnContinue} />)
+      fireEvent.click(screen.getByRole('button', { name: /Continue to Level 3/i }))
+      expect(mockOnContinue).toHaveBeenCalledTimes(1)
+    })
+
+    it('has min touch target of 44px', () => {
+      render(<LevelUpScreen completedLevel={1} onContinue={mockOnContinue} />)
+      const button = screen.getByRole('button', { name: /Continue/i })
+      expect(button.className).toContain('min-h-[44px]')
+    })
+  })
+
+  // ── Max level guard ────────────────────────────────────────────────
+
+  describe('max level (level 13)', () => {
+    it('does not show "Next" level name when completed level is 13', () => {
+      render(<LevelUpScreen completedLevel={13} onContinue={mockOnContinue} />)
+      expect(screen.queryByText(/Next:/)).toBeNull()
+    })
+
+    it('shows completed level 13 name (Math Champion)', () => {
+      render(<LevelUpScreen completedLevel={13} onContinue={mockOnContinue} />)
+      expect(screen.getAllByText(/Math Champion/).length).toBeGreaterThanOrEqual(1)
+    })
+
+    it('shows a different CTA for max level (no level number)', () => {
+      render(<LevelUpScreen completedLevel={13} onContinue={mockOnContinue} />)
+      const button = screen.getByRole('button')
+      expect(button.textContent).not.toContain('Level 14')
+    })
+
+    it('CTA button still calls onContinue for max level', () => {
+      render(<LevelUpScreen completedLevel={13} onContinue={mockOnContinue} />)
+      fireEvent.click(screen.getByRole('button'))
+      expect(mockOnContinue).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  // ── Various completed levels ───────────────────────────────────────
+
+  describe('various completed levels', () => {
+    it('renders correctly for level 1', () => {
+      render(<LevelUpScreen completedLevel={1} onContinue={mockOnContinue} />)
+      expect(screen.getAllByText(/First Steps/).length).toBeGreaterThanOrEqual(1)
+      expect(screen.getAllByText(/Addition Hero/).length).toBeGreaterThanOrEqual(1)
+    })
+
+    it('renders correctly for level 7', () => {
+      render(<LevelUpScreen completedLevel={7} onContinue={mockOnContinue} />)
+      expect(screen.getAllByText(/Mixed 20/).length).toBeGreaterThanOrEqual(1)
+      expect(screen.getAllByText(/Tens Master/).length).toBeGreaterThanOrEqual(1)
+    })
+
+    it('renders correctly for level 12', () => {
+      render(<LevelUpScreen completedLevel={12} onContinue={mockOnContinue} />)
+      expect(screen.getAllByText(/Division Quest/).length).toBeGreaterThanOrEqual(1)
+      expect(screen.getAllByText(/Math Champion/).length).toBeGreaterThanOrEqual(1)
+    })
+  })
+
+  // ── Accessibility ──────────────────────────────────────────────────
+
+  describe('accessibility', () => {
+    it('has aria-live="polite" on announcement region', () => {
+      render(<LevelUpScreen completedLevel={1} onContinue={mockOnContinue} />)
+      const region = screen.getByRole('status')
+      expect(region.getAttribute('aria-live')).toBe('polite')
+    })
+
+    it('has role="status" on announcement region', () => {
+      render(<LevelUpScreen completedLevel={1} onContinue={mockOnContinue} />)
+      expect(screen.getByRole('status')).toBeTruthy()
+    })
+
+    it('uses proper heading hierarchy (h1 for main heading)', () => {
+      render(<LevelUpScreen completedLevel={1} onContinue={mockOnContinue} />)
+      const heading = screen.getByRole('heading', { level: 1 })
+      expect(heading.textContent).toBe('Level Complete!')
+    })
+  })
+
+  // ── Reduced motion ─────────────────────────────────────────────────
+
+  describe('reduced motion', () => {
+    it('hero emoji has motion-reduce class to disable animation', () => {
+      render(<LevelUpScreen completedLevel={1} onContinue={mockOnContinue} />)
+      const hero = screen.getByTestId('hero-emoji')
+      expect(hero.className).toContain('motion-reduce:animate-none')
+    })
+
+    it('confetti particles have motion-reduce class', () => {
+      render(<LevelUpScreen completedLevel={1} onContinue={mockOnContinue} />)
+      const particles = screen.getAllByTestId('confetti-particle')
+      particles.forEach((particle) => {
+        expect(particle.className).toContain('motion-reduce:hidden')
+      })
+    })
+  })
+})

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -12,6 +12,7 @@
  * - ProfileSwitcher: Avatar card grid for selecting profiles
  * - PinEntry: 4-dot numpad PIN overlay (presentational)
  * - CreateProfile: 4-step wizard for creating new profiles
+ * - LevelUpScreen: Celebration screen when player levels up
  */
 
 export { default as Problem } from './Problem'
@@ -24,3 +25,4 @@ export { default as ResultScreen } from './ResultScreen'
 export { default as ProfileSwitcher } from './ProfileSwitcher'
 export { default as PinEntry } from './PinEntry'
 export { default as CreateProfile } from './CreateProfile'
+export { default as LevelUpScreen } from './LevelUpScreen'

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -27,6 +27,8 @@ export default {
         'aid-enter': 'aid-enter 350ms ease-out forwards',
         'arc-draw': 'arc-draw 600ms ease-in-out forwards',
         'step-fade': 'step-fade 300ms ease-out forwards',
+        'bounce-hero': 'bounce-hero 1s ease-in-out infinite',
+        'confetti-fall': 'confetti-fall 2s ease-out forwards',
       },
       keyframes: {
         'pop-in': {
@@ -73,6 +75,15 @@ export default {
         'step-fade': {
           '0%': { opacity: '0', transform: 'translateX(-4px)' },
           '100%': { opacity: '1', transform: 'translateX(0)' },
+        },
+        'bounce-hero': {
+          '0%, 100%': { transform: 'translateY(0) scale(1)' },
+          '50%': { transform: 'translateY(-20px) scale(1.1)' },
+        },
+        'confetti-fall': {
+          '0%': { transform: 'translateY(-100vh) rotate(0deg)', opacity: '1' },
+          '80%': { opacity: '1' },
+          '100%': { transform: 'translateY(100vh) rotate(720deg)', opacity: '0' },
         },
       },
     },


### PR DESCRIPTION
## Summary
Implements the level-up celebration screen with App.jsx screen state machine integration.

### Changes
- **New:** `src/components/LevelUpScreen.jsx` — celebration component with hero emoji, bounce animation, CSS confetti, accessibility
- **Modified:** `src/App.jsx` — added `'levelup'` screen state, `handleLevelUp`/`handleContinueAfterLevelUp` handlers
- **Modified:** `src/components/GameScreen.jsx` — useEffect detects `shouldLevelUp && !showFeedback`, calls `onLevelUp`
- **Modified:** `src/components/index.js` — barrel export
- **Modified:** `tailwind.config.js` — bounce-hero, confetti-fall animations

### Tests
- 35 new tests (21 LevelUpScreen + 8 GameScreen + 6 App integration)
- 659 total passing

### Acceptance Criteria
- [x] LevelUpScreen with hero emoji, bounce, confetti, CTA button
- [x] App.jsx 'levelup' screen state
- [x] GameScreen shouldLevelUp detection via useEffect
- [x] Continue button updates profile currentLevel
- [x] Max level guard (no currentLevel: 14)
- [x] Reduced-motion support
- [x] Accessibility (aria-live, role=status)
- [x] data-testid="audio-placeholder"

Closes #78
Part of epic #28