### PR TITLE
feat(#79): max-level champion screen

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,6 +2,7 @@ import { useState, useCallback } from 'react'
 import { useFirebase, useGameProgress } from './hooks'
 import { StartScreen, GameScreen, ResultScreen, LevelUpScreen, ProfileSwitcher, CreateProfile } from './components'
 import { useProfile } from './context/useProfile'
+import { MAX_LEVEL } from './config/levels'
 
 /**
  * App Component - Main application with screen navigation
@@ -136,8 +137,8 @@ function App() {
   const handleContinueAfterLevelUp = useCallback(() => {
     if (completedLevel !== null && activeProfile) {
       const nextLevel = completedLevel + 1
-      // Max level guard: do not update profile beyond LEVELS.length (13)
-      if (nextLevel <= 13) {
+      // Max level guard: do not update profile beyond MAX_LEVEL
+      if (nextLevel <= MAX_LEVEL) {
         updateProfile(activeProfile.id, { currentLevel: nextLevel })
       }
     }

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -7,6 +7,11 @@ import { createElement } from 'react'
 
 // ─── Mocks ────────────────────────────────────────────────────────────────────
 
+// Mock levels config (App imports MAX_LEVEL)
+vi.mock('./config/levels', () => ({
+  MAX_LEVEL: 13,
+}))
+
 // Mock useProfile hook
 const mockProfileContext = {
   activeProfile: null,

--- a/src/components/LevelUpScreen.jsx
+++ b/src/components/LevelUpScreen.jsx
@@ -5,6 +5,10 @@
  * 'start', 'game', 'result'). Displays celebration animation,
  * completed level info, and a CTA to continue to the next level.
  *
+ * When the player completes the final level (MAX_LEVEL), a special
+ * "Champion" variant is shown with a trophy emoji, a distinct title,
+ * and a "Play Again at Level 13!" button that does NOT increment.
+ *
  * Visual MVP: emoji hero + CSS confetti particles, no audio.
  *
  * @param {Object}   props
@@ -13,7 +17,7 @@
  */
 
 import PropTypes from 'prop-types'
-import { LEVELS } from '../config/levels'
+import { LEVELS, MAX_LEVEL } from '../config/levels'
 
 /** Number of confetti particles to render */
 const CONFETTI_COUNT = 12
@@ -30,8 +34,8 @@ const CONFETTI_COLORS = [
 
 function LevelUpScreen({ completedLevel, onContinue }) {
   const completedLevelConfig = LEVELS[completedLevel - 1]
-  const isMaxLevel = completedLevel >= LEVELS.length
-  const nextLevelConfig = isMaxLevel ? null : LEVELS[completedLevel]
+  const isChampion = completedLevel >= MAX_LEVEL
+  const nextLevelConfig = isChampion ? null : LEVELS[completedLevel]
 
   return (
     <div className="min-h-screen bg-gradient-to-b from-sonic-blue to-blue-900 flex flex-col items-center justify-center p-4 relative overflow-hidden">
@@ -55,32 +59,35 @@ function LevelUpScreen({ completedLevel, onContinue }) {
         />
       ))}
 
-      {/* Hero emoji with bounce animation */}
+      {/* Hero emoji with bounce animation — trophy for champion, rocket otherwise */}
       <div
         data-testid="hero-emoji"
         className="text-7xl md:text-8xl mb-4 animate-bounce-hero motion-reduce:animate-none"
         aria-hidden="true"
       >
-        🚀
+        {isChampion ? '\uD83C\uDFC6' : '\uD83D\uDE80'}
       </div>
 
       {/* Screen-reader announcement */}
       <div role="status" aria-live="polite" className="sr-only">
-        Level complete! You finished {completedLevelConfig?.name}.
-        {nextLevelConfig ? ` Next up: ${nextLevelConfig.name}.` : ' You have completed all levels!'}
+        {isChampion
+          ? `Congratulations! You mastered all ${MAX_LEVEL} levels!`
+          : `Level complete! You finished ${completedLevelConfig?.name}. Next up: ${nextLevelConfig?.name}.`}
       </div>
 
       {/* Main heading */}
       <h1 className="text-4xl md:text-6xl font-game text-sonic-gold drop-shadow-lg text-center mb-2">
-        Level Complete!
+        {isChampion ? 'Math Champion!' : 'Level Complete!'}
       </h1>
 
-      {/* Completed level name */}
+      {/* Sub-message */}
       <p className="text-xl md:text-2xl font-game text-white text-center mb-1">
-        {completedLevelConfig?.name}
+        {isChampion
+          ? `You mastered all ${MAX_LEVEL} levels!`
+          : completedLevelConfig?.name}
       </p>
 
-      {/* Next level subheading */}
+      {/* Next level subheading (normal flow only) */}
       {nextLevelConfig && (
         <p className="text-lg md:text-xl font-game text-yellow-200 text-center mb-8">
           Next: {nextLevelConfig.name}
@@ -102,13 +109,13 @@ function LevelUpScreen({ completedLevel, onContinue }) {
           focus:outline-none focus:ring-2 focus:ring-yellow-300
         "
         aria-label={
-          isMaxLevel
-            ? 'Continue playing'
+          isChampion
+            ? `Play Again at Level ${MAX_LEVEL}`
             : `Continue to Level ${completedLevel + 1}`
         }
       >
-        {isMaxLevel
-          ? 'Keep Playing!'
+        {isChampion
+          ? `Play Again at Level ${MAX_LEVEL}!`
           : `Continue to Level ${completedLevel + 1}!`}
       </button>
 

--- a/src/components/LevelUpScreen.test.jsx
+++ b/src/components/LevelUpScreen.test.jsx
@@ -21,6 +21,7 @@ vi.mock('../config/levels', () => ({
     { id: 12, name: 'Division Quest' },
     { id: 13, name: 'Math Champion' },
   ],
+  MAX_LEVEL: 13,
 }))
 
 // Import after mocks
@@ -101,12 +102,7 @@ describe('LevelUpScreen', () => {
       expect(screen.queryByText(/Next:/)).toBeNull()
     })
 
-    it('shows completed level 13 name (Math Champion)', () => {
-      render(<LevelUpScreen completedLevel={13} onContinue={mockOnContinue} />)
-      expect(screen.getAllByText(/Math Champion/).length).toBeGreaterThanOrEqual(1)
-    })
-
-    it('shows a different CTA for max level (no level number)', () => {
+    it('shows a different CTA for max level (no level number 14)', () => {
       render(<LevelUpScreen completedLevel={13} onContinue={mockOnContinue} />)
       const button = screen.getByRole('button')
       expect(button.textContent).not.toContain('Level 14')
@@ -116,6 +112,92 @@ describe('LevelUpScreen', () => {
       render(<LevelUpScreen completedLevel={13} onContinue={mockOnContinue} />)
       fireEvent.click(screen.getByRole('button'))
       expect(mockOnContinue).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  // ── Champion variant (level 13 completion) ───────────────────────
+
+  describe('champion variant', () => {
+    it('shows "Math Champion!" heading instead of "Level Complete!"', () => {
+      render(<LevelUpScreen completedLevel={13} onContinue={mockOnContinue} />)
+      expect(screen.getByRole('heading', { level: 1 }).textContent).toBe('Math Champion!')
+      expect(screen.queryByText('Level Complete!')).toBeNull()
+    })
+
+    it('shows trophy emoji instead of rocket', () => {
+      render(<LevelUpScreen completedLevel={13} onContinue={mockOnContinue} />)
+      const hero = screen.getByTestId('hero-emoji')
+      expect(hero.textContent).toBe('\uD83C\uDFC6')
+      expect(hero.textContent).not.toBe('\uD83D\uDE80')
+    })
+
+    it('shows "You mastered all 13 levels!" message', () => {
+      render(<LevelUpScreen completedLevel={13} onContinue={mockOnContinue} />)
+      expect(screen.getByText('You mastered all 13 levels!')).toBeTruthy()
+    })
+
+    it('shows "Play Again at Level 13!" button', () => {
+      render(<LevelUpScreen completedLevel={13} onContinue={mockOnContinue} />)
+      const button = screen.getByRole('button')
+      expect(button.textContent).toBe('Play Again at Level 13!')
+    })
+
+    it('button has correct aria-label for champion', () => {
+      render(<LevelUpScreen completedLevel={13} onContinue={mockOnContinue} />)
+      const button = screen.getByRole('button')
+      expect(button.getAttribute('aria-label')).toBe('Play Again at Level 13')
+    })
+
+    it('screen-reader announcement mentions mastering all levels', () => {
+      render(<LevelUpScreen completedLevel={13} onContinue={mockOnContinue} />)
+      const status = screen.getByRole('status')
+      expect(status.textContent).toContain('mastered all 13 levels')
+    })
+
+    it('confetti still renders in champion mode', () => {
+      render(<LevelUpScreen completedLevel={13} onContinue={mockOnContinue} />)
+      const particles = screen.getAllByTestId('confetti-particle')
+      expect(particles.length).toBeGreaterThanOrEqual(8)
+    })
+
+    it('hero emoji still has bounce animation in champion mode', () => {
+      render(<LevelUpScreen completedLevel={13} onContinue={mockOnContinue} />)
+      const hero = screen.getByTestId('hero-emoji')
+      expect(hero.className).toContain('animate-bounce-hero')
+    })
+
+    it('does not show the completed level config name as sub-message', () => {
+      render(<LevelUpScreen completedLevel={13} onContinue={mockOnContinue} />)
+      // The sub-message should be "You mastered all 13 levels!" not the level name
+      // The level name "Math Champion" could appear in heading — but NOT as level config display
+      const paragraphs = screen.getAllByText(/mastered all 13/)
+      expect(paragraphs.length).toBeGreaterThanOrEqual(1)
+    })
+  })
+
+  // ── Boundary: level 12 to 13 (normal level-up) ───────────────────
+
+  describe('boundary: level 12 (normal level-up to 13)', () => {
+    it('shows "Level Complete!" heading for level 12', () => {
+      render(<LevelUpScreen completedLevel={12} onContinue={mockOnContinue} />)
+      expect(screen.getByRole('heading', { level: 1 }).textContent).toBe('Level Complete!')
+    })
+
+    it('shows rocket emoji for level 12', () => {
+      render(<LevelUpScreen completedLevel={12} onContinue={mockOnContinue} />)
+      const hero = screen.getByTestId('hero-emoji')
+      expect(hero.textContent).toBe('\uD83D\uDE80')
+    })
+
+    it('shows "Continue to Level 13!" button for level 12', () => {
+      render(<LevelUpScreen completedLevel={12} onContinue={mockOnContinue} />)
+      const button = screen.getByRole('button', { name: /Continue to Level 13/i })
+      expect(button.textContent).toBe('Continue to Level 13!')
+    })
+
+    it('shows Next: Math Champion for level 12', () => {
+      render(<LevelUpScreen completedLevel={12} onContinue={mockOnContinue} />)
+      expect(screen.getByText(/Next: Math Champion/)).toBeTruthy()
     })
   })
 

--- a/src/config/levels.js
+++ b/src/config/levels.js
@@ -1,3 +1,6 @@
+/** Total number of levels — use this instead of magic number 13 */
+export const MAX_LEVEL = 13
+
 export const LEVELS = [
   { id: 1,  name: 'First Steps',     operators: ['+'],           minNumber: 1, maxNumber: 5,   ageTarget: '5-6'  },
   { id: 2,  name: 'Addition Hero',   operators: ['+'],           minNumber: 1, maxNumber: 10,  ageTarget: '6'    },


### PR DESCRIPTION
## Summary
Part of epic #28 (Level Progression UI). Handles the edge case when a player completes level 13 (the max level).

- **Champion variant** in `LevelUpScreen`: trophy emoji, "Math Champion!" title, "You mastered all 13 levels!" message, "Play Again at Level 13!" button
- **`MAX_LEVEL` constant** exported from `levels.js` — replaces magic number `13` in both `App.jsx` and `LevelUpScreen.jsx`
- **Max-level guard** in `App.jsx`: `handleContinueAfterLevelUp` uses `MAX_LEVEL` to prevent `updateProfile` from being called with `currentLevel: 14`
- **11 new tests** covering champion variant rendering, boundary (level 12 normal -> level 13 champion), a11y, and no-level-14 guard

## Acceptance Criteria
- [x] `completedLevel === 13` shows champion variant (trophy, different title/message)
- [x] "Play Again at Level 13!" button returns to game at level 13 (no increment)
- [x] `getLevelConfig(14)` is never called
- [x] `updateProfile` is NOT called with `currentLevel: 14`
- [x] Level 12 completion shows normal "Level Complete!" with "Continue to Level 13!"
- [x] All 697 tests pass, 0 lint errors

## Test Plan
- `npm run lint` -- 0 errors
- `npx vitest run` -- 697 tests passing (22 test files)

Closes #79