### PR TITLE
feat(#87): i18n infrastructure + translation files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,10 @@
       "version": "0.0.1",
       "dependencies": {
         "firebase": "^12.10.0",
+        "i18next": "^25.8.18",
         "react": "^18.3.1",
-        "react-dom": "^18.3.1"
+        "react-dom": "^18.3.1",
+        "react-i18next": "^16.5.8"
       },
       "devDependencies": {
         "@eslint/js": "^9.17.0",
@@ -1644,7 +1646,6 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
       "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -6527,6 +6528,15 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
+    "node_modules/html-parse-stringify": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
+      "integrity": "sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==",
+      "license": "MIT",
+      "dependencies": {
+        "void-elements": "3.1.0"
+      }
+    },
     "node_modules/http-parser-js": {
       "version": "0.5.10",
       "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.10.tgz",
@@ -6559,6 +6569,37 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/i18next": {
+      "version": "25.8.18",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-25.8.18.tgz",
+      "integrity": "sha512-lzY5X83BiL5AP77+9DydbrqkQHFN9hUzWGjqjLpPcp5ZOzuu1aSoKaU3xbBLSjWx9dAzW431y+d+aogxOZaKRA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://locize.com"
+        },
+        {
+          "type": "individual",
+          "url": "https://locize.com/i18next.html"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.6"
+      },
+      "peerDependencies": {
+        "typescript": "^5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/idb": {
@@ -8396,6 +8437,33 @@
         "react": "^18.3.1"
       }
     },
+    "node_modules/react-i18next": {
+      "version": "16.5.8",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-16.5.8.tgz",
+      "integrity": "sha512-2ABeHHlakxVY+LSirD+OiERxFL6+zip0PaHo979bgwzeHg27Sqc82xxXWIrSFmfWX0ZkrvXMHwhsi/NGUf5VQg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.4",
+        "html-parse-stringify": "^3.0.1",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "i18next": ">= 25.6.2",
+        "react": ">= 16.8.0",
+        "typescript": "^5"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -9831,6 +9899,15 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -10074,6 +10151,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/void-elements": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
+      "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/w3c-xmlserializer": {

--- a/package.json
+++ b/package.json
@@ -16,8 +16,10 @@
   },
   "dependencies": {
     "firebase": "^12.10.0",
+    "i18next": "^25.8.18",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "react-i18next": "^16.5.8"
   },
   "devDependencies": {
     "@eslint/js": "^9.17.0",

--- a/src/i18n/i18n.test.js
+++ b/src/i18n/i18n.test.js
@@ -1,0 +1,233 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import i18n from 'i18next'
+import { initReactI18next } from 'react-i18next'
+import he from './locales/he.json'
+import en from './locales/en.json'
+
+/**
+ * Flatten a nested JSON object into dot-notation keys.
+ * Arrays are treated as leaf values (not recursed into).
+ *
+ * @param {Object} obj
+ * @param {string} prefix
+ * @returns {string[]}
+ */
+function flattenKeys(obj, prefix = '') {
+  return Object.keys(obj).reduce((acc, key) => {
+    const path = prefix ? `${prefix}.${key}` : key
+    if (typeof obj[key] === 'object' && obj[key] !== null && !Array.isArray(obj[key])) {
+      return [...acc, ...flattenKeys(obj[key], path)]
+    }
+    return [...acc, path]
+  }, [])
+}
+
+describe('i18n configuration', () => {
+  let testI18n
+
+  beforeEach(async () => {
+    testI18n = i18n.createInstance()
+    await testI18n.use(initReactI18next).init({
+      resources: {
+        he: { translation: he },
+        en: { translation: en },
+      },
+      lng: 'he',
+      fallbackLng: 'en',
+      interpolation: {
+        escapeValue: false,
+      },
+      react: {
+        useSuspense: false,
+      },
+    })
+  })
+
+  it('initializes without errors', () => {
+    expect(testI18n.isInitialized).toBe(true)
+  })
+
+  it('default language is Hebrew', () => {
+    expect(testI18n.language).toBe('he')
+  })
+
+  it('can change language to English', async () => {
+    await testI18n.changeLanguage('en')
+    expect(testI18n.language).toBe('en')
+  })
+
+  it('can change language back to Hebrew', async () => {
+    await testI18n.changeLanguage('en')
+    await testI18n.changeLanguage('he')
+    expect(testI18n.language).toBe('he')
+  })
+
+  it('returns Hebrew translation for start.title', () => {
+    const result = testI18n.t('start.title')
+    expect(result).toBe('סוניק מתמטיקה!')
+  })
+
+  it('returns English translation when language is en', async () => {
+    await testI18n.changeLanguage('en')
+    const result = testI18n.t('start.title')
+    expect(result).toBe('Sonic Math Trainer!')
+  })
+
+  it('falls back to English for missing Hebrew keys', () => {
+    // Verify that fallback works by checking a key exists in both
+    const heResult = testI18n.t('common.loading')
+    expect(heResult).toBe('טוען...')
+  })
+
+  it('interpolation works with Hebrew', () => {
+    const result = testI18n.t('start.accuracy', { percent: 85 })
+    expect(result).toBe('דיוק: 85%')
+  })
+
+  it('interpolation works with English', async () => {
+    await testI18n.changeLanguage('en')
+    const result = testI18n.t('start.accuracy', { percent: 85 })
+    expect(result).toBe('Accuracy: 85%')
+  })
+
+  it('interpolation works for profile level', () => {
+    const result = testI18n.t('profile.level', { level: 5 })
+    expect(result).toBe('שלב 5')
+  })
+
+  it('interpolation works for pin digits', async () => {
+    await testI18n.changeLanguage('en')
+    const result = testI18n.t('pin.digitsEntered', { count: 2, total: 4 })
+    expect(result).toBe('2 of 4 digits entered')
+  })
+
+  it('returns array values for feedback.correct', () => {
+    const result = testI18n.t('feedback.correct', { returnObjects: true })
+    expect(Array.isArray(result)).toBe(true)
+    expect(result).toHaveLength(8)
+  })
+
+  it('returns array values for feedback.wrong', () => {
+    const result = testI18n.t('feedback.wrong', { returnObjects: true })
+    expect(Array.isArray(result)).toBe(true)
+    expect(result).toHaveLength(6)
+  })
+})
+
+describe('translation completeness', () => {
+  const heKeys = flattenKeys(he)
+  const enKeys = flattenKeys(en)
+
+  it('en.json has all keys from he.json', () => {
+    const missing = heKeys.filter(k => !enKeys.includes(k))
+    expect(missing).toEqual([])
+  })
+
+  it('he.json has all keys from en.json', () => {
+    const missing = enKeys.filter(k => !heKeys.includes(k))
+    expect(missing).toEqual([])
+  })
+
+  it('both languages have the same number of keys', () => {
+    expect(heKeys.length).toBe(enKeys.length)
+  })
+
+  it('has at least 90 translation keys', () => {
+    expect(heKeys.length).toBeGreaterThanOrEqual(90)
+  })
+
+  it('feedback.correct arrays have the same length in both languages', () => {
+    expect(he.feedback.correct.length).toBe(en.feedback.correct.length)
+  })
+
+  it('feedback.wrong arrays have the same length in both languages', () => {
+    expect(he.feedback.wrong.length).toBe(en.feedback.wrong.length)
+  })
+})
+
+describe('translation key groups', () => {
+  it('has app keys', () => {
+    expect(en.app).toBeDefined()
+    expect(en.app.loading).toBeDefined()
+    expect(en.app.errorTitle).toBeDefined()
+  })
+
+  it('has start screen keys', () => {
+    expect(en.start).toBeDefined()
+    expect(en.start.title).toBeDefined()
+    expect(en.start.startButton).toBeDefined()
+  })
+
+  it('has game screen keys', () => {
+    expect(en.game).toBeDefined()
+    expect(en.game.exit).toBeDefined()
+  })
+
+  it('has result screen keys', () => {
+    expect(en.result).toBeDefined()
+    expect(en.result.title).toBeDefined()
+    expect(en.result.playAgain).toBeDefined()
+  })
+
+  it('has score display keys', () => {
+    expect(en.score).toBeDefined()
+    expect(en.score.score).toBeDefined()
+    expect(en.score.streak).toBeDefined()
+  })
+
+  it('has feedback keys', () => {
+    expect(en.feedback).toBeDefined()
+    expect(en.feedback.correct).toHaveLength(8)
+    expect(en.feedback.wrong).toHaveLength(6)
+  })
+
+  it('has profile keys', () => {
+    expect(en.profile).toBeDefined()
+    expect(en.profile.title).toBeDefined()
+    expect(en.profile.createHero).toBeDefined()
+  })
+
+  it('has pin entry keys', () => {
+    expect(en.pin).toBeDefined()
+    expect(en.pin.enterPin).toBeDefined()
+  })
+
+  it('has create profile keys', () => {
+    expect(en.create).toBeDefined()
+    expect(en.create.whatIsYourName).toBeDefined()
+    expect(en.create.chooseHero).toBeDefined()
+  })
+
+  it('has level up keys', () => {
+    expect(en.levelup).toBeDefined()
+    expect(en.levelup.levelComplete).toBeDefined()
+    expect(en.levelup.mathChampion).toBeDefined()
+  })
+
+  it('has level map keys', () => {
+    expect(en.levelmap).toBeDefined()
+    expect(en.levelmap.ariaLabel).toBeDefined()
+  })
+
+  it('has strategy keys', () => {
+    expect(en.strategy).toBeDefined()
+    expect(en.strategy.names).toBeDefined()
+    expect(en.strategy.names.bridging_add).toBeDefined()
+  })
+
+  it('has learning aid keys', () => {
+    expect(en.learningAid).toBeDefined()
+    expect(en.learningAid.dismiss).toBeDefined()
+  })
+
+  it('has dot counter keys', () => {
+    expect(en.dotCounter).toBeDefined()
+    expect(en.dotCounter.addLabel).toBeDefined()
+  })
+
+  it('has common keys', () => {
+    expect(en.common).toBeDefined()
+    expect(en.common.loading).toBeDefined()
+    expect(en.common.cancel).toBeDefined()
+  })
+})

--- a/src/i18n/index.js
+++ b/src/i18n/index.js
@@ -1,0 +1,21 @@
+import i18n from 'i18next'
+import { initReactI18next } from 'react-i18next'
+import he from './locales/he.json'
+import en from './locales/en.json'
+
+i18n.use(initReactI18next).init({
+  resources: {
+    he: { translation: he },
+    en: { translation: en },
+  },
+  lng: 'he',
+  fallbackLng: 'en',
+  interpolation: {
+    escapeValue: false,
+  },
+  react: {
+    useSuspense: false,
+  },
+})
+
+export default i18n

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1,0 +1,182 @@
+{
+  "app": {
+    "loading": "Loading...",
+    "loadingHeroes": "Loading heroes...",
+    "loadingConnection": "Connecting to Sonic Speed!",
+    "loadingProgress": "Loading your progress...",
+    "errorTitle": "Oops!",
+    "errorConnection": "Could not connect to save your progress",
+    "playAnyway": "Play Anyway!"
+  },
+  "start": {
+    "title": "Sonic Math Trainer!",
+    "subtitle": "Time to boost your math power!",
+    "yourBest": "Your Best:",
+    "points": "points",
+    "streak": "streak",
+    "accuracy": "Accuracy: {{percent}}%",
+    "startButton": "Start Game!",
+    "tip": "Tap the correct answer to score points!",
+    "footer": "Math is fun!"
+  },
+  "game": {
+    "exit": "Exit",
+    "loading": "Loading..."
+  },
+  "result": {
+    "title": "Great Job!",
+    "points": "Points",
+    "bestStreak": "Best Streak",
+    "accuracy": "Accuracy",
+    "problems": "Problems",
+    "playAgain": "Play Again!",
+    "backToStart": "Back to Start",
+    "footer": "Keep practicing to become a Math Master!",
+    "performance": {
+      "high": "Sonic Speed! Amazing!",
+      "medium": "Great effort! Keep practicing!",
+      "low": "You're learning! Try again!"
+    }
+  },
+  "score": {
+    "score": "Score",
+    "streak": "Streak",
+    "streakLabels": {
+      "fire": "On Fire!",
+      "lightning": "Lightning!",
+      "speedy": "Speedy!",
+      "keepGoing": "Keep going!"
+    }
+  },
+  "feedback": {
+    "correct": [
+      "Sonic Speed!",
+      "Amazing!",
+      "Perfect!",
+      "Great Job!",
+      "You're on Fire!",
+      "Super Star!",
+      "Awesome!",
+      "Incredible!"
+    ],
+    "wrong": [
+      "Try Again!",
+      "Almost There!",
+      "Keep Going!",
+      "You've Got This!",
+      "So Close!",
+      "One More Try!"
+    ]
+  },
+  "problem": {
+    "ariaLabel": "Math Problem",
+    "answerOptions": "Answer Options",
+    "answer": "Answer: {{answer}}"
+  },
+  "profile": {
+    "title": "Who's playing?",
+    "welcomeTitle": "Welcome to Math Trainer!",
+    "welcomeSubtitle": "Create your first hero to start playing!",
+    "createHero": "+ Create Hero",
+    "addHero": "Add Hero",
+    "level": "Level {{level}}",
+    "selectProfile": "Select {{name}}, Level {{level}}",
+    "createFirstHero": "Create your first hero profile",
+    "createNewHero": "Create a new hero profile",
+    "pinError": "Oops! Wrong PIN. Try again.",
+    "genericError": "Something went wrong. Try again."
+  },
+  "pin": {
+    "enterPin": "Enter PIN",
+    "enterPinFor": "Enter PIN for {{name}}",
+    "digitsEntered": "{{count}} of {{total}} digits entered",
+    "tooManyTries": "Too many tries! Wait {{seconds}}s",
+    "checking": "Checking...",
+    "back": "Back",
+    "deleteDigit": "Delete last digit",
+    "cancelPin": "Cancel PIN entry",
+    "digit": "Digit {{key}}"
+  },
+  "create": {
+    "dialogLabel": "Create a new hero profile",
+    "progress": "Profile creation progress",
+    "stepOf": "Step {{step}} of {{total}}",
+    "stepCurrent": "Step {{step}} of {{total}}, current",
+    "stepCompleted": "Step {{step}} of {{total}}, completed",
+    "whatIsYourName": "What is your name?",
+    "typeName": "Type your name...",
+    "enterNickname": "Enter your nickname",
+    "charsLeft": "{{count}} characters left",
+    "next": "Next",
+    "cancel": "Cancel",
+    "continueToTheme": "Continue to theme selection",
+    "chooseHero": "Choose your hero!",
+    "selectTheme": "Select a theme",
+    "themeLabel": "{{name}} theme",
+    "continueToPin": "Continue to PIN entry",
+    "choosePinTitle": "Choose a secret PIN",
+    "confirmPinTitle": "Confirm your PIN",
+    "pinMismatch": "PINs do not match. Try again!",
+    "pinError": "Could not process PIN. Try again.",
+    "creatingHero": "Creating your hero...",
+    "createError": "Could not create hero. Try again!",
+    "tryAgain": "Try Again",
+    "tryAgainLabel": "Try creating your hero again",
+    "back": "Back",
+    "backLabel": "Go back to previous step",
+    "cancelLabel": "Cancel profile creation"
+  },
+  "levelup": {
+    "levelComplete": "Level Complete!",
+    "mathChampion": "Math Champion!",
+    "masteredAll": "You mastered all {{count}} levels!",
+    "srComplete": "Level complete! You finished {{completed}}. Next up: {{next}}.",
+    "srChampion": "Congratulations! You mastered all {{count}} levels!",
+    "next": "Next: {{name}}",
+    "continueToLevel": "Continue to Level {{level}}",
+    "playAgainAtLevel": "Play Again at Level {{level}}",
+    "continueButton": "Continue to Level {{level}}!",
+    "playAgainButton": "Play Again at Level {{level}}!"
+  },
+  "levelmap": {
+    "ariaLabel": "Level progress map",
+    "levelStatus": "Level {{id}}: {{name}} - {{status}}",
+    "completed": "completed",
+    "current": "current",
+    "locked": "locked"
+  },
+  "champion": {
+    "title": "Math Champion!",
+    "message": "You mastered all {{count}} levels!"
+  },
+  "strategy": {
+    "names": {
+      "bridging_add": "Bridge to 10",
+      "bridging_sub": "Bridge to 10",
+      "doubles": "Use Doubles",
+      "near_doubles": "Near Doubles",
+      "count_on": "Count On",
+      "count_back": "Count Back"
+    },
+    "hintFor": "Strategy hint for {{num1}} {{operator}} {{num2}}",
+    "counter": "Strategy {{current}} of {{total}}",
+    "showAnother": "Show me another way",
+    "showAnotherLabel": "Show me another way to solve this problem"
+  },
+  "learningAid": {
+    "dismiss": "I got it!",
+    "dismissLabel": "Dismiss learning aid"
+  },
+  "dotCounter": {
+    "addLabel": "{{num1}} blue dots plus {{num2}} gold dots",
+    "subLabel": "{{num1}} blue dots minus {{num2}} faded dots"
+  },
+  "common": {
+    "loading": "Loading...",
+    "error": "Error",
+    "back": "Back",
+    "next": "Next",
+    "confirm": "Confirm",
+    "cancel": "Cancel"
+  }
+}

--- a/src/i18n/locales/he.json
+++ b/src/i18n/locales/he.json
@@ -1,0 +1,182 @@
+{
+  "app": {
+    "loading": "טוען...",
+    "loadingHeroes": "טוען גיבורים...",
+    "loadingConnection": "מתחבר לסוניק!",
+    "loadingProgress": "טוען את ההתקדמות שלך...",
+    "errorTitle": "אופס!",
+    "errorConnection": "לא הצלחנו לשמור את ההתקדמות שלך",
+    "playAnyway": "בוא נשחק!"
+  },
+  "start": {
+    "title": "סוניק מתמטיקה!",
+    "subtitle": "בוא נתרגל חשבון!",
+    "yourBest": "השיא שלך:",
+    "points": "נקודות",
+    "streak": "רצף",
+    "accuracy": "דיוק: {{percent}}%",
+    "startButton": "התחל משחק!",
+    "tip": "לחץ על התשובה הנכונה!",
+    "footer": "חשבון זה כיף!"
+  },
+  "game": {
+    "exit": "יציאה",
+    "loading": "טוען..."
+  },
+  "result": {
+    "title": "כל הכבוד!",
+    "points": "נקודות",
+    "bestStreak": "רצף הכי טוב",
+    "accuracy": "דיוק",
+    "problems": "תרגילים",
+    "playAgain": "שחק שוב!",
+    "backToStart": "חזרה להתחלה",
+    "footer": "תמשיך לתרגל ותהיה אלוף חשבון!",
+    "performance": {
+      "high": "מהירות סוניק! מדהים!",
+      "medium": "יופי! תמשיך לתרגל!",
+      "low": "אתה לומד! נסה שוב!"
+    }
+  },
+  "score": {
+    "score": "ניקוד",
+    "streak": "רצף",
+    "streakLabels": {
+      "fire": "בוער!",
+      "lightning": "ברק!",
+      "speedy": "מהיר!",
+      "keepGoing": "המשך!"
+    }
+  },
+  "feedback": {
+    "correct": [
+      "מהירות סוניק!",
+      "מדהים!",
+      "מושלם!",
+      "כל הכבוד!",
+      "אתה בוער!",
+      "כוכב על!",
+      "מעולה!",
+      "אדיר!"
+    ],
+    "wrong": [
+      "נסה שוב!",
+      "כמעט!",
+      "המשך!",
+      "אתה יכול!",
+      "קרוב מאוד!",
+      "עוד ניסיון!"
+    ]
+  },
+  "problem": {
+    "ariaLabel": "תרגיל חשבון",
+    "answerOptions": "אפשרויות תשובה",
+    "answer": "תשובה: {{answer}}"
+  },
+  "profile": {
+    "title": "מי משחק?",
+    "welcomeTitle": "ברוכים הבאים!",
+    "welcomeSubtitle": "צור את הגיבור הראשון שלך!",
+    "createHero": "+ צור גיבור",
+    "addHero": "הוסף גיבור",
+    "level": "שלב {{level}}",
+    "selectProfile": "בחר {{name}}, שלב {{level}}",
+    "createFirstHero": "צור את הגיבור הראשון שלך",
+    "createNewHero": "צור גיבור חדש",
+    "pinError": "אופס! קוד שגוי. נסה שוב.",
+    "genericError": "משהו השתבש. נסה שוב."
+  },
+  "pin": {
+    "enterPin": "הכנס קוד",
+    "enterPinFor": "הכנס קוד עבור {{name}}",
+    "digitsEntered": "{{count}} מתוך {{total}} ספרות",
+    "tooManyTries": "יותר מדי ניסיונות! חכה {{seconds}} שניות",
+    "checking": "בודק...",
+    "back": "חזרה",
+    "deleteDigit": "מחק ספרה",
+    "cancelPin": "בטל הזנת קוד",
+    "digit": "ספרה {{key}}"
+  },
+  "create": {
+    "dialogLabel": "יצירת גיבור חדש",
+    "progress": "התקדמות יצירת גיבור",
+    "stepOf": "שלב {{step}} מתוך {{total}}",
+    "stepCurrent": "שלב {{step}} מתוך {{total}}, נוכחי",
+    "stepCompleted": "שלב {{step}} מתוך {{total}}, הושלם",
+    "whatIsYourName": "מה השם שלך?",
+    "typeName": "כתוב את השם שלך...",
+    "enterNickname": "הכנס את הכינוי שלך",
+    "charsLeft": "{{count}} תווים נותרו",
+    "next": "הבא",
+    "cancel": "ביטול",
+    "continueToTheme": "המשך לבחירת גיבור",
+    "chooseHero": "בחר את הגיבור שלך!",
+    "selectTheme": "בחר נושא",
+    "themeLabel": "נושא {{name}}",
+    "continueToPin": "המשך להזנת קוד",
+    "choosePinTitle": "בחר קוד סודי",
+    "confirmPinTitle": "אשר את הקוד",
+    "pinMismatch": "הקודים לא תואמים. נסה שוב!",
+    "pinError": "לא הצלחנו לעבד את הקוד. נסה שוב.",
+    "creatingHero": "יוצר את הגיבור שלך...",
+    "createError": "לא הצלחנו ליצור גיבור. נסה שוב!",
+    "tryAgain": "נסה שוב",
+    "tryAgainLabel": "נסה ליצור את הגיבור שוב",
+    "back": "חזרה",
+    "backLabel": "חזור לשלב הקודם",
+    "cancelLabel": "בטל יצירת גיבור"
+  },
+  "levelup": {
+    "levelComplete": "השלב הושלם!",
+    "mathChampion": "אלוף חשבון!",
+    "masteredAll": "סיימת את כל {{count}} השלבים!",
+    "srComplete": "השלב הושלם! סיימת את {{completed}}. הבא: {{next}}.",
+    "srChampion": "מזל טוב! סיימת את כל {{count}} השלבים!",
+    "next": "הבא: {{name}}",
+    "continueToLevel": "המשך לשלב {{level}}",
+    "playAgainAtLevel": "שחק שוב בשלב {{level}}",
+    "continueButton": "המשך לשלב {{level}}!",
+    "playAgainButton": "שחק שוב בשלב {{level}}!"
+  },
+  "levelmap": {
+    "ariaLabel": "מפת התקדמות שלבים",
+    "levelStatus": "שלב {{id}}: {{name}} - {{status}}",
+    "completed": "הושלם",
+    "current": "נוכחי",
+    "locked": "נעול"
+  },
+  "champion": {
+    "title": "אלוף חשבון!",
+    "message": "סיימת את כל {{count}} השלבים!"
+  },
+  "strategy": {
+    "names": {
+      "bridging_add": "גשר ל-10",
+      "bridging_sub": "גשר ל-10",
+      "doubles": "כפולות",
+      "near_doubles": "כמעט כפול",
+      "count_on": "ספור קדימה",
+      "count_back": "ספור אחורה"
+    },
+    "hintFor": "רמז לתרגיל {{num1}} {{operator}} {{num2}}",
+    "counter": "דרך {{current}} מתוך {{total}}",
+    "showAnother": "הראה דרך אחרת",
+    "showAnotherLabel": "הראה דרך אחרת לפתור את התרגיל"
+  },
+  "learningAid": {
+    "dismiss": "הבנתי!",
+    "dismissLabel": "סגור עזרה"
+  },
+  "dotCounter": {
+    "addLabel": "{{num1}} נקודות כחולות ועוד {{num2}} נקודות זהב",
+    "subLabel": "{{num1}} נקודות כחולות פחות {{num2}} נקודות דהויות"
+  },
+  "common": {
+    "loading": "טוען...",
+    "error": "שגיאה",
+    "back": "חזרה",
+    "next": "הבא",
+    "confirm": "אישור",
+    "cancel": "ביטול"
+  }
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,13 +1,17 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
+import { I18nextProvider } from 'react-i18next'
+import i18n from './i18n/index.js'
 import App from './App.jsx'
 import ProfileProvider from './context/ProfileContext.jsx'
 import './styles/index.css'
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
-    <ProfileProvider>
-      <App />
-    </ProfileProvider>
+    <I18nextProvider i18n={i18n}>
+      <ProfileProvider>
+        <App />
+      </ProfileProvider>
+    </I18nextProvider>
   </React.StrictMode>,
 )

--- a/src/main.test.jsx
+++ b/src/main.test.jsx
@@ -28,6 +28,19 @@ vi.mock('./context/ProfileContext.jsx', () => ({
   default: function MockProfileProvider({ children }) { return children },
 }))
 
+vi.mock('./i18n/index.js', () => ({
+  default: { language: 'he' },
+}))
+
+vi.mock('react-i18next', () => ({
+  I18nextProvider: function MockI18nextProvider({ children }) { return children },
+  useTranslation: () => ({
+    t: (key) => key,
+    i18n: { changeLanguage: vi.fn(), language: 'he' },
+  }),
+  initReactI18next: { type: '3rdParty', init: vi.fn() },
+}))
+
 vi.mock('./styles/index.css', () => ({}))
 
 describe('main.jsx', () => {
@@ -52,13 +65,15 @@ describe('main.jsx', () => {
     expect(capturedElement).not.toBeNull()
   })
 
-  it('wraps App inside ProfileProvider inside StrictMode', () => {
-    // The rendered element is: <StrictMode><ProfileProvider><App /></ProfileProvider></StrictMode>
+  it('wraps App inside I18nextProvider inside ProfileProvider inside StrictMode', () => {
+    // The rendered element is: <StrictMode><I18nextProvider><ProfileProvider><App /></ProfileProvider></I18nextProvider></StrictMode>
     expect(capturedElement.type).toBe(React.StrictMode.type ?? React.StrictMode)
 
-    const providerElement = capturedElement.props.children
-    expect(providerElement).toBeTruthy()
-    // ProfileProvider wraps App
-    expect(providerElement.props.children).toBeTruthy()
+    const i18nProviderElement = capturedElement.props.children
+    expect(i18nProviderElement).toBeTruthy()
+    // I18nextProvider wraps ProfileProvider which wraps App
+    const profileProviderElement = i18nProviderElement.props.children
+    expect(profileProviderElement).toBeTruthy()
+    expect(profileProviderElement.props.children).toBeTruthy()
   })
 })

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -1,0 +1,28 @@
+/**
+ * Global i18n test setup for Vitest
+ *
+ * Since no components have been migrated to use useTranslation() yet
+ * (that happens in issues #89-#91), this setup file only needs to
+ * ensure that i18next is available if any test indirectly triggers
+ * an import. It initializes a minimal i18n instance with English
+ * translations so existing tests continue to pass unchanged.
+ */
+import i18n from 'i18next'
+import { initReactI18next } from 'react-i18next'
+
+// Only initialize once
+if (!i18n.isInitialized) {
+  i18n.use(initReactI18next).init({
+    resources: {
+      en: { translation: {} },
+    },
+    lng: 'en',
+    fallbackLng: 'en',
+    interpolation: {
+      escapeValue: false,
+    },
+    react: {
+      useSuspense: false,
+    },
+  })
+}

--- a/src/test-utils/index.js
+++ b/src/test-utils/index.js
@@ -1,0 +1,1 @@
+export { renderWithI18n, createTestI18n } from './renderWithI18n'

--- a/src/test-utils/renderWithI18n.jsx
+++ b/src/test-utils/renderWithI18n.jsx
@@ -1,0 +1,71 @@
+/**
+ * Test utility: renderWithI18n
+ *
+ * Wraps a component in an I18nextProvider with a fresh i18n instance
+ * for integration-level tests that need real translations.
+ *
+ * For most unit tests, the global setupTests.js i18n mock is sufficient.
+ * Use this helper when you need to test language switching or verify
+ * translated output in a specific language.
+ *
+ * @example
+ * import { renderWithI18n } from '../test-utils'
+ * const { getByText } = renderWithI18n(<MyComponent />, { language: 'he' })
+ */
+
+import { render } from '@testing-library/react'
+import i18n from 'i18next'
+import { I18nextProvider, initReactI18next } from 'react-i18next'
+import he from '../i18n/locales/he.json'
+import en from '../i18n/locales/en.json'
+
+/**
+ * Creates a fresh i18n instance for testing.
+ *
+ * @param {string} lng - Initial language ('he' or 'en')
+ * @returns {import('i18next').i18n} Initialized i18n instance
+ */
+export function createTestI18n(lng = 'en') {
+  const instance = i18n.createInstance()
+  instance.use(initReactI18next).init({
+    resources: {
+      he: { translation: he },
+      en: { translation: en },
+    },
+    lng,
+    fallbackLng: 'en',
+    interpolation: {
+      escapeValue: false,
+    },
+    react: {
+      useSuspense: false,
+    },
+  })
+  return instance
+}
+
+/**
+ * Render a component wrapped in I18nextProvider.
+ *
+ * @param {import('react').ReactElement} ui - Component to render
+ * @param {Object} [options]
+ * @param {string} [options.language='en'] - Language for the i18n instance
+ * @param {import('@testing-library/react').RenderOptions} [options.renderOptions] - Additional render options
+ * @returns {{ i18n: import('i18next').i18n } & import('@testing-library/react').RenderResult}
+ */
+export function renderWithI18n(ui, { language = 'en', ...renderOptions } = {}) {
+  const i18nInstance = createTestI18n(language)
+
+  function Wrapper({ children }) {
+    return (
+      <I18nextProvider i18n={i18nInstance}>
+        {children}
+      </I18nextProvider>
+    )
+  }
+
+  return {
+    ...render(ui, { wrapper: Wrapper, ...renderOptions }),
+    i18n: i18nInstance,
+  }
+}

--- a/src/utils/profiles.js
+++ b/src/utils/profiles.js
@@ -29,6 +29,12 @@ export const PIN_LENGTH = 4;
 /** @type {string[]} Valid theme identifiers */
 export const VALID_THEMES = ['sonic', 'spiderman'];
 
+/** @type {string[]} Valid language identifiers */
+export const VALID_LANGUAGES = ['he', 'en'];
+
+/** @type {string} Default language for new profiles */
+export const DEFAULT_LANGUAGE = 'he';
+
 // ─── Internal Helpers ───────────────────────────────────────────────────────
 
 /**
@@ -116,6 +122,7 @@ export function getProfileById(id) {
  * @param {string} data.pinHash - SHA-256 hex digest of the PIN (64 chars)
  * @param {string|null} [data.firebaseUid=null] - Firebase anonymous auth UID
  * @param {number} [data.currentLevel=1] - Starting level
+ * @param {string} [data.language='he'] - Language preference ('he' or 'en')
  * @returns {Object} The newly created profile object
  * @throws {Error} If MAX_PROFILES reached, or if nickname/theme/pinHash are invalid
  *
@@ -126,7 +133,7 @@ export function getProfileById(id) {
  *   pinHash: 'a1b2c3...64chars'
  * });
  */
-export function createProfile({ nickname, theme, pinHash, firebaseUid = null, currentLevel = 1 }) {
+export function createProfile({ nickname, theme, pinHash, firebaseUid = null, currentLevel = 1, language = DEFAULT_LANGUAGE }) {
   const profiles = readStorage();
 
   if (profiles.length >= MAX_PROFILES) {
@@ -160,6 +167,7 @@ export function createProfile({ nickname, theme, pinHash, firebaseUid = null, cu
     pinHash,
     firebaseUid,
     currentLevel,
+    language: VALID_LANGUAGES.includes(language) ? language : DEFAULT_LANGUAGE,
     createdAt: now,
     lastActiveAt: now
   };
@@ -274,5 +282,7 @@ export default {
   updateProfile,
   deleteProfile,
   hashPin,
-  verifyPin
+  verifyPin,
+  VALID_LANGUAGES,
+  DEFAULT_LANGUAGE
 };

--- a/src/utils/profiles.test.js
+++ b/src/utils/profiles.test.js
@@ -27,6 +27,8 @@ const {
   MAX_NICKNAME_LENGTH,
   PIN_LENGTH,
   VALID_THEMES,
+  VALID_LANGUAGES,
+  DEFAULT_LANGUAGE,
   getProfiles,
   getProfileById,
   createProfile,
@@ -68,6 +70,14 @@ describe('profiles', () => {
 
     it('VALID_THEMES contains sonic and spiderman', () => {
       expect(VALID_THEMES).toEqual(['sonic', 'spiderman']);
+    });
+
+    it('VALID_LANGUAGES contains he and en', () => {
+      expect(VALID_LANGUAGES).toEqual(['he', 'en']);
+    });
+
+    it('DEFAULT_LANGUAGE is he', () => {
+      expect(DEFAULT_LANGUAGE).toBe('he');
     });
   });
 
@@ -269,6 +279,49 @@ describe('profiles', () => {
         createProfile({ nickname: `P${i}`, theme: 'sonic', pinHash: VALID_PIN_HASH });
       }
       expect(getProfiles()).toHaveLength(MAX_PROFILES);
+    });
+  });
+
+  // ─── Language Field ──────────────────────────────────────────────────
+
+  describe('language field', () => {
+    it('defaults to Hebrew when language is not specified', () => {
+      const profile = createProfile({ nickname: 'NoLang', theme: 'sonic', pinHash: VALID_PIN_HASH });
+      expect(profile.language).toBe('he');
+    });
+
+    it('accepts Hebrew as explicit language', () => {
+      const profile = createProfile({ nickname: 'Hebrew', theme: 'sonic', pinHash: VALID_PIN_HASH, language: 'he' });
+      expect(profile.language).toBe('he');
+    });
+
+    it('accepts English as explicit language', () => {
+      const profile = createProfile({ nickname: 'English', theme: 'sonic', pinHash: VALID_PIN_HASH, language: 'en' });
+      expect(profile.language).toBe('en');
+    });
+
+    it('falls back to Hebrew for invalid language', () => {
+      const profile = createProfile({ nickname: 'Invalid', theme: 'sonic', pinHash: VALID_PIN_HASH, language: 'fr' });
+      expect(profile.language).toBe('he');
+    });
+
+    it('persists language to localStorage', () => {
+      createProfile({ nickname: 'Persist', theme: 'sonic', pinHash: VALID_PIN_HASH, language: 'en' });
+      const stored = JSON.parse(localStorage.getItem(STORAGE_KEY));
+      expect(stored[0].language).toBe('en');
+    });
+
+    it('can update language via updateProfile', () => {
+      const profile = createProfile({ nickname: 'Switch', theme: 'sonic', pinHash: VALID_PIN_HASH });
+      expect(profile.language).toBe('he');
+      const updated = updateProfile(profile.id, { language: 'en' });
+      expect(updated.language).toBe('en');
+    });
+
+    it('language is preserved after updating other fields', () => {
+      const profile = createProfile({ nickname: 'Keep', theme: 'sonic', pinHash: VALID_PIN_HASH, language: 'en' });
+      const updated = updateProfile(profile.id, { currentLevel: 5 });
+      expect(updated.language).toBe('en');
     });
   });
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -6,6 +6,7 @@ import { VitePWA } from 'vite-plugin-pwa'
 export default defineConfig({
   test: {
     exclude: ['tests/**', 'node_modules/**'],
+    setupFiles: ['./src/setupTests.js'],
   },
   plugins: [
     react(),


### PR DESCRIPTION
## Summary

Closes #87

**Parent Epic:** #21 — Phase 4: i18n Hebrew + English

### What this PR does
Sets up the i18n infrastructure and translation files for the math-trainer app, enabling Hebrew and English language support.

### Sub-issue of
- Epic #21 — Phase 4: i18n Hebrew + English
- This is Group 1 (first sub-issue) — foundational infrastructure that all subsequent i18n sub-issues (#88, #89, #90, #91, #92) depend on.

### Target
This PR targets the **epic branch** `epic/21-i18n-hebrew-english`, not `develop`.