### PR TITLE
fix: CreateProfile wizard stuck on PIN confirmation step

### DIFF
--- a/src/components/CreateProfile.jsx
+++ b/src/components/CreateProfile.jsx
@@ -534,6 +534,7 @@ function CreateProfile({ onComplete, onCancel }) {
   /** Step 3: PIN entry */
   const renderPinStep = () => (
     <PinEntry
+      key="pin-set"
       profileName="Choose a secret PIN"
       onSubmit={handlePinSet}
       onCancel={handleBack}
@@ -548,6 +549,7 @@ function CreateProfile({ onComplete, onCancel }) {
   /** Step 4: PIN confirmation */
   const renderPinConfirmStep = () => (
     <PinEntry
+      key="pin-confirm"
       profileName="Confirm your PIN"
       onSubmit={handlePinConfirm}
       onCancel={handleBack}

--- a/src/components/CreateProfile.test.jsx
+++ b/src/components/CreateProfile.test.jsx
@@ -88,9 +88,6 @@ async function goToStep4(name = 'TestHero', pin = '1234') {
   completeThemeStep()
   enterPin(pin)
   await flush()
-  // PinEntry reconciles from step 3 to step 4 -- digits carry over.
-  // Clear them with backspace so the step-4 PinEntry is ready for input.
-  clearPinDigits()
 }
 
 /**
@@ -110,21 +107,6 @@ async function enterMismatchedPinAndFlush(pin = '9999') {
   mockHashPin.mockResolvedValueOnce('different-hash')
   enterPin(pin)
   await flush()
-}
-
-/**
- * Clear all 4 digits in the PinEntry via backspace button.
- * After step 3 -> step 4 reconciliation, digits carry over and
- * must be cleared before entering the confirmation PIN.
- */
-function clearPinDigits() {
-  const backspaceBtn = screen.queryByLabelText('Delete last digit')
-  if (!backspaceBtn) return
-  for (let i = 0; i < 4; i++) {
-    if (!backspaceBtn.disabled) {
-      fireEvent.click(backspaceBtn)
-    }
-  }
 }
 
 // ─── Tests ───────────────────────────────────────────────────────────────────
@@ -766,8 +748,7 @@ describe('CreateProfile', () => {
       await flush()
       expect(screen.getByText('Confirm your PIN')).toBeTruthy()
 
-      // Step 4: confirm PIN (clear stale digits from step 3 first)
-      clearPinDigits()
+      // Step 4: confirm PIN
       mockHashPin.mockResolvedValueOnce('hash-abc')
       enterPin('1234')
       await flush()
@@ -803,8 +784,7 @@ describe('CreateProfile', () => {
       mockHashPin.mockResolvedValueOnce('new-hash-5555')
       enterPin('5555')
       await flush()
-      // On step 4 with new hash -- clear stale digits from step 3
-      clearPinDigits()
+      // On step 4 with new hash
       // Confirm with new matching hash
       mockHashPin.mockResolvedValueOnce('new-hash-5555')
       enterPin('5555')


### PR DESCRIPTION
## Severity
**P0 — Production blocker.** The CreateProfile wizard is unusable: users cannot complete PIN confirmation (step 4).

## Root Cause
React reconciliation bug. Steps 3 (set PIN) and 4 (confirm PIN) both render a `<PinEntry>` component at the same tree position without distinct keys. React reuses the existing component instance, preserving the internal `digits` state from step 3. Since all 4 digits are already filled, every digit button is disabled in step 4 — the user is stuck.

## Fix
- Add `key="pin-set"` to the PinEntry in step 3 and `key="pin-confirm"` to step 4
- React now unmounts/remounts PinEntry when transitioning between steps, resetting internal state
- Remove the `clearPinDigits()` test workaround that was masking the bug by manually resetting state

## Files Changed
- `src/components/CreateProfile.jsx` — add distinct keys to PinEntry components
- `src/components/CreateProfile.test.jsx` — remove clearPinDigits workaround (4 insertions, 22 deletions)

## Test Verification
- All 613 tests pass
- PIN confirmation flow tested end-to-end in CreateProfile test suite
- No test workarounds remain