### PR TITLE
#112: StartScreen button + App.jsx screen state integration

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,6 @@
 import { useState, useCallback } from 'react'
 import { useFirebase, useGameProgress } from './hooks'
-import { StartScreen, GameScreen, ResultScreen, LevelUpScreen, ProfileSwitcher, CreateProfile } from './components'
+import { StartScreen, GameScreen, ResultScreen, LevelUpScreen, ProfileSwitcher, CreateProfile, ProgressView } from './components'
 import { useProfile } from './context/useProfile'
 import { MAX_LEVEL } from './config/levels'
 
@@ -16,9 +16,14 @@ import { MAX_LEVEL } from './config/levels'
  *                                      |
  *                                      v (onComplete)
  * [activeProfile set]             -> StartScreen -> GameScreen -> ResultScreen
- *                                      ^            |    |         |
- *                                      +------------+----+---------+
- *                                                   |
+ *                                      ^    |       |    |         |
+ *                                      +----+-------+----+---------+
+ *                                      |    |
+ *                                      |    v (My Progress)
+ *                                      | ProgressView
+ *                                      |    |
+ *                                      +----+ (Close)
+ *                                           |
  *                                                   v (shouldLevelUp)
  *                                               LevelUpScreen
  *                                                   |
@@ -27,7 +32,7 @@ import { MAX_LEVEL } from './config/levels'
  *
  * Manages:
  * - Profile-gated entry: shows ProfileSwitcher or CreateProfile when no active profile
- * - Screen state ('start', 'game', 'result', 'levelup')
+ * - Screen state ('start', 'game', 'result', 'levelup', 'progress')
  * - Firebase authentication
  * - Game progress persistence (keyed to activeProfile.firebaseUid)
  * - Session statistics between screens
@@ -102,6 +107,11 @@ function App() {
     setSessionStats(null) // Clear session stats
     setScreen('start')
   }, [forceSave])
+
+  // Handle navigating to progress view
+  const handleViewProgress = useCallback(() => {
+    setScreen('progress')
+  }, [])
 
   // Handle switching profile (back to switcher)
   const handleSwitchProfile = useCallback(() => {
@@ -217,10 +227,20 @@ function App() {
       {screen === 'start' && (
         <StartScreen
           onStart={handleStartGame}
+          onViewProgress={handleViewProgress}
           progress={progress}
           onSwitchProfile={handleSwitchProfile}
           activeProfile={activeProfile}
           currentLevel={currentLevel}
+        />
+      )}
+
+      {screen === 'progress' && (
+        <ProgressView
+          currentLevel={currentLevel}
+          progress={progress}
+          activeProfile={activeProfile}
+          onClose={() => setScreen('start')}
         />
       )}
 

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -44,10 +44,13 @@ vi.mock('./hooks', () => ({
 
 // Mock child components to isolate App logic
 vi.mock('./components', () => ({
-  StartScreen: ({ onStart, onSwitchProfile }) =>
+  StartScreen: ({ onStart, onSwitchProfile, onViewProgress }) =>
     createElement('div', { 'data-testid': 'start-screen' },
       createElement('button', { 'data-testid': 'start-game', onClick: onStart }, 'Start'),
       createElement('button', { 'data-testid': 'switch-profile', onClick: onSwitchProfile }, 'Switch'),
+      onViewProgress
+        ? createElement('button', { 'data-testid': 'view-progress', onClick: onViewProgress }, 'My Progress')
+        : null,
     ),
   GameScreen: ({ onGameEnd, currentLevel, onLevelUp }) =>
     createElement('div', { 'data-testid': 'game-screen', 'data-current-level': currentLevel },
@@ -91,6 +94,14 @@ vi.mock('./components', () => ({
         }),
       }, 'Complete'),
       createElement('button', { 'data-testid': 'cancel-wizard', onClick: onCancel }, 'Cancel'),
+    ),
+  ProgressView: ({ currentLevel, onClose, activeProfile }) =>
+    createElement('div', {
+      'data-testid': 'progress-view',
+      'data-current-level': currentLevel,
+      'data-profile-id': activeProfile?.id || '',
+    },
+      createElement('button', { 'data-testid': 'close-progress', onClick: onClose }, 'Close'),
     ),
 }))
 
@@ -540,6 +551,105 @@ describe('App', () => {
       render(<App />)
 
       expect(screen.queryByTestId('levelup-screen')).toBeNull()
+    })
+  })
+
+  // ── Progress view flow ──────────────────────────────────────────────
+
+  describe('progress view flow', () => {
+    it('navigates from start to progress view when My Progress is clicked', () => {
+      mockProfileContext.activeProfile = {
+        id: '1',
+        nickname: 'Dubi',
+        firebaseUid: 'uid-1',
+        currentLevel: 3,
+      }
+      render(<App />)
+
+      fireEvent.click(screen.getByTestId('view-progress'))
+      expect(screen.getByTestId('progress-view')).toBeTruthy()
+      expect(screen.queryByTestId('start-screen')).toBeNull()
+    })
+
+    it('navigates from progress view back to start when Close is clicked', () => {
+      mockProfileContext.activeProfile = {
+        id: '1',
+        nickname: 'Dubi',
+        firebaseUid: 'uid-1',
+        currentLevel: 3,
+      }
+      render(<App />)
+
+      // Navigate to progress
+      fireEvent.click(screen.getByTestId('view-progress'))
+      expect(screen.getByTestId('progress-view')).toBeTruthy()
+
+      // Close progress
+      fireEvent.click(screen.getByTestId('close-progress'))
+      expect(screen.getByTestId('start-screen')).toBeTruthy()
+      expect(screen.queryByTestId('progress-view')).toBeNull()
+    })
+
+    it('passes currentLevel to ProgressView', () => {
+      mockProfileContext.activeProfile = {
+        id: '1',
+        nickname: 'Dubi',
+        firebaseUid: 'uid-1',
+        currentLevel: 7,
+      }
+      render(<App />)
+
+      fireEvent.click(screen.getByTestId('view-progress'))
+      const progressView = screen.getByTestId('progress-view')
+      expect(progressView.getAttribute('data-current-level')).toBe('7')
+    })
+
+    it('passes activeProfile to ProgressView', () => {
+      mockProfileContext.activeProfile = {
+        id: 'profile-42',
+        nickname: 'Dubi',
+        firebaseUid: 'uid-1',
+        currentLevel: 1,
+      }
+      render(<App />)
+
+      fireEvent.click(screen.getByTestId('view-progress'))
+      const progressView = screen.getByTestId('progress-view')
+      expect(progressView.getAttribute('data-profile-id')).toBe('profile-42')
+    })
+
+    it('does not show progress view on initial render', () => {
+      mockProfileContext.activeProfile = {
+        id: '1',
+        nickname: 'Dubi',
+        firebaseUid: 'uid-1',
+        currentLevel: 1,
+      }
+      render(<App />)
+
+      expect(screen.queryByTestId('progress-view')).toBeNull()
+    })
+
+    it('can navigate start -> progress -> start -> game (full round trip)', () => {
+      mockProfileContext.activeProfile = {
+        id: '1',
+        nickname: 'Dubi',
+        firebaseUid: 'uid-1',
+        currentLevel: 1,
+      }
+      render(<App />)
+
+      // Start -> Progress
+      fireEvent.click(screen.getByTestId('view-progress'))
+      expect(screen.getByTestId('progress-view')).toBeTruthy()
+
+      // Progress -> Start
+      fireEvent.click(screen.getByTestId('close-progress'))
+      expect(screen.getByTestId('start-screen')).toBeTruthy()
+
+      // Start -> Game
+      fireEvent.click(screen.getByTestId('start-game'))
+      expect(screen.getByTestId('game-screen')).toBeTruthy()
     })
   })
 })

--- a/src/components/StartScreen.jsx
+++ b/src/components/StartScreen.jsx
@@ -23,7 +23,7 @@ import { getTheme } from '../config/themes'
  * @param {number} progress.correctAnswers - Total correct answers
  * @param {number} [currentLevel=1] - The player's current level (1-13)
  */
-function StartScreen({ onStart, progress = null, currentLevel = 1, activeProfile = null }) {
+function StartScreen({ onStart, onViewProgress, progress = null, currentLevel = 1, activeProfile = null }) {
   const theme = getTheme(activeProfile?.theme)
 
   // Check if user has previous progress to display
@@ -135,6 +135,29 @@ function StartScreen({ onStart, progress = null, currentLevel = 1, activeProfile
           Start Game!
         </button>
 
+        {/* My Progress Button - secondary styling, visible when profile is active */}
+        {activeProfile && (
+          <button
+            onClick={onViewProgress}
+            className="
+              mt-4
+              bg-white/20 hover:bg-white/30
+              text-white font-game text-xl md:text-2xl
+              px-10 py-4 rounded-2xl
+              shadow-md
+              transform transition-all duration-300
+              hover:scale-105
+              active:scale-95
+              focus:outline-none focus:ring-4 focus:ring-white/40
+              min-w-[44px] min-h-[44px]
+            "
+            aria-label="View my progress"
+            data-testid="my-progress-button"
+          >
+            My Progress
+          </button>
+        )}
+
         {/* Encouraging Tip */}
         <p className="text-lg md:text-xl font-game text-white/70 mt-8">
           <span role="img" aria-label="star">&#x2B50;</span> Tap the correct answer to score points!{' '}
@@ -152,6 +175,7 @@ function StartScreen({ onStart, progress = null, currentLevel = 1, activeProfile
 
 StartScreen.propTypes = {
   onStart: PropTypes.func.isRequired,
+  onViewProgress: PropTypes.func,
   progress: PropTypes.shape({
     score: PropTypes.number,
     streak: PropTypes.number,

--- a/src/components/StartScreen.test.jsx
+++ b/src/components/StartScreen.test.jsx
@@ -2,7 +2,7 @@
  * @vitest-environment happy-dom
  */
 import { describe, it, expect, afterEach, vi, beforeEach } from 'vitest'
-import { render, screen, cleanup } from '@testing-library/react'
+import { render, screen, cleanup, fireEvent } from '@testing-library/react'
 import StartScreen from './StartScreen'
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
@@ -51,5 +51,66 @@ describe('StartScreen — LevelMap integration', () => {
     render(<StartScreen onStart={vi.fn()} />)
     const node1 = screen.getByTestId('level-node-1')
     expect(node1.getAttribute('aria-label')).toBe('Level 1: First Steps - current')
+  })
+})
+
+describe('StartScreen — My Progress button', () => {
+  beforeEach(() => {
+    Element.prototype.scrollIntoView = vi.fn()
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.restoreAllMocks()
+  })
+
+  it('renders the My Progress button when activeProfile is provided', () => {
+    renderStartScreen({
+      activeProfile: { theme: 'sonic' },
+      onViewProgress: vi.fn(),
+    })
+    expect(screen.getByTestId('my-progress-button')).toBeTruthy()
+    expect(screen.getByText('My Progress')).toBeTruthy()
+  })
+
+  it('does not render the My Progress button when activeProfile is null', () => {
+    renderStartScreen({
+      activeProfile: null,
+      onViewProgress: vi.fn(),
+    })
+    expect(screen.queryByTestId('my-progress-button')).toBeNull()
+  })
+
+  it('does not render the My Progress button when activeProfile is not provided', () => {
+    renderStartScreen()
+    expect(screen.queryByTestId('my-progress-button')).toBeNull()
+  })
+
+  it('calls onViewProgress when the My Progress button is clicked', () => {
+    const onViewProgress = vi.fn()
+    renderStartScreen({
+      activeProfile: { theme: 'sonic' },
+      onViewProgress,
+    })
+    fireEvent.click(screen.getByTestId('my-progress-button'))
+    expect(onViewProgress).toHaveBeenCalledTimes(1)
+  })
+
+  it('has correct aria-label for accessibility', () => {
+    renderStartScreen({
+      activeProfile: { theme: 'sonic' },
+      onViewProgress: vi.fn(),
+    })
+    const button = screen.getByTestId('my-progress-button')
+    expect(button.getAttribute('aria-label')).toBe('View my progress')
+  })
+
+  it('renders Start Game button alongside My Progress button', () => {
+    renderStartScreen({
+      activeProfile: { theme: 'sonic' },
+      onViewProgress: vi.fn(),
+    })
+    expect(screen.getByText('Start Game!')).toBeTruthy()
+    expect(screen.getByText('My Progress')).toBeTruthy()
   })
 })

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1,4 +1,7 @@
 {
+  "startScreen": {
+    "myProgress": "My Progress"
+  },
   "progress": {
     "title": "My Progress",
     "accuracyFraction": "{{correct}} out of {{total}} correct!",

--- a/src/i18n/locales/he.json
+++ b/src/i18n/locales/he.json
@@ -1,4 +1,7 @@
 {
+  "startScreen": {
+    "myProgress": "\u05d4\u05d4\u05ea\u05e7\u05d3\u05de\u05d5\u05ea \u05e9\u05dc\u05d9"
+  },
   "progress": {
     "title": "\u05d4\u05d4\u05ea\u05e7\u05d3\u05de\u05d5\u05ea \u05e9\u05dc\u05d9",
     "accuracyFraction": "{{correct}} \u05de\u05ea\u05d5\u05da {{total}} \u05e0\u05db\u05d5\u05e0\u05d9\u05dd!",


### PR DESCRIPTION
## Sub-issue #112 of #34

Navigation integration:
- 'My Progress' button on StartScreen
- screen='progress' state in App.jsx
- Wire navigation: StartScreen -> ProgressView -> StartScreen
- Pass props: currentLevel, progress, activeProfile, onClose
- 10+ tests

Closes #112