### PR TITLE
Promote epic #28: Level Progression UI (v1.4.0)

### DIFF
--- a/.github/TL_STATE.json
+++ b/.github/TL_STATE.json
@@ -3,8 +3,8 @@
   "repo": "math-trainer",
   "projectNumber": 6,
   "projectId": "PVT_kwHOA54Ghc4BQtkw",
-  "currentPhase": "epic-complete",
-  "currentStep": "3.9",
+  "currentPhase": "baking",
+  "currentStep": "3.5.2",
   "currentIssue": 28,
   "currentSubIssue": null,
   "currentPR": null,
@@ -24,7 +24,7 @@
   "activeParentIssue": {
     "number": 28,
     "title": "Phase 7 — Level Progression UI",
-    "currentStep": "3.9"
+    "currentStep": "3.5.2"
   },
   "epics": [
     {"phase": 1, "epicNumber": 11, "title": "Phase 1 — Level Config + Problem Generator", "priority": "P0", "subIssues": [12, 13], "status": "complete"},
@@ -32,8 +32,8 @@
     {"phase": 3, "epicNumber": 17, "title": "Phase 3 — Multi-Profile System", "priority": "P0", "subIssues": [18, 19, 20], "issue19SubIssues": [53, 54, 55], "status": "complete"},
     {"phase": 4, "epicNumber": 21, "title": "Phase 4 — i18n Hebrew + English", "priority": "P1", "subIssues": [87, 88, 89, 90, 91, 92], "legacySubIssues": [22]},
     {"phase": 5, "epicNumber": 23, "title": "Phase 5 — Superhero Theme System", "priority": "P1", "subIssues": [24]},
-    {"phase": 6, "epicNumber": 25, "title": "Phase 6 — Learning Aids", "priority": "P0", "subIssues": [26, 27], "status": "complete"},
-    {"phase": 7, "epicNumber": 28, "title": "Phase 7 — Level Progression UI", "priority": "P0", "subIssues": [77, 78, 79, 80, 81], "legacySubIssues": [29, 30], "status": "epic-complete"},
+    {"phase": 6, "epicNumber": 25, "title": "Phase 6 — Learning Aids", "priority": "P0", "subIssues": [26, 27], "status": "promoted"},
+    {"phase": 7, "epicNumber": 28, "title": "Phase 7 — Level Progression UI", "priority": "P0", "subIssues": [77, 78, 79, 80, 81], "legacySubIssues": [29, 30], "status": "baking"},
     {"phase": 8, "epicNumber": 31, "title": "Phase 8 — Leaderboard", "priority": "P1", "subIssues": [32]},
     {"phase": 9, "epicNumber": 33, "title": "Phase 9 — Progress Visualization", "priority": "P1", "subIssues": [34]},
     {"phase": 10, "epicNumber": 35, "title": "Phase 10 — AI Teaching Videos", "priority": "P2", "subIssues": [36]},
@@ -91,7 +91,7 @@
     {"epicNumber": 11, "title": "Phase 1 — Level Config + Problem Generator", "completedAt": "2026-03-08"},
     {"epicNumber": 14, "title": "Phase 2 — Confidence Engine", "completedAt": "2026-03-08"},
     {"epicNumber": 17, "title": "Phase 3 — Multi-Profile System", "completedAt": "2026-03-09", "version": "v1.2.0", "promotionPR": 62},
-    {"epicNumber": 25, "title": "Phase 6 — Learning Aids", "completedAt": "2026-03-09", "prs": [67, 68, 69, 70, 71, 75]}
+    {"epicNumber": 25, "title": "Phase 6 — Learning Aids", "completedAt": "2026-03-12", "version": "v1.3.0", "promotionPR": 76, "mergeCommit": "c90d211"}
   ],
   "parallelWorkstreams": {
     "aiVideoContent": {
@@ -106,14 +106,14 @@
   "blockedIssues": [],
   "bakingEpics": [
     {
-      "epicNumber": 25,
-      "title": "Phase 6 — Learning Aids",
-      "promotionPR": 76,
-      "bakeStartDate": "2026-03-09",
-      "consecutiveGreenDays": 3,
-      "status": "ready-for-promotion",
-      "subIssues": [26, 27],
-      "allSubIssuesClosed": true
+      "epicNumber": 28,
+      "title": "Phase 7 — Level Progression UI",
+      "bakeStartDate": "2026-03-12",
+      "consecutiveGreenDays": 0,
+      "status": "baking",
+      "subIssues": [77, 78, 79, 80, 81],
+      "allSubIssuesClosed": true,
+      "mergeCommit": "eaa35e9"
     }
   ],
   "closedLegacyIssues": [3, 4, 6, 7],
@@ -123,16 +123,19 @@
     "dailyResults": [
       {"date": "2026-03-10", "result": "pass"},
       {"date": "2026-03-11", "result": "pass"},
-      {"date": "2026-03-11-manual", "result": "pass", "runId": 22973622119}
+      {"date": "2026-03-11-manual", "result": "pass", "runId": 22973622119},
+      {"date": "2026-03-12-pre-promote", "result": "pass", "runId": 22976954653}
     ],
-    "consecutiveGreenDays": 3,
-    "status": "ready-for-promotion",
-    "promotionPR": 76
+    "consecutiveGreenDays": 4,
+    "status": "promoted",
+    "promotionPR": 76,
+    "mergeCommit": "c90d211",
+    "promotedAt": "2026-03-12"
   },
   "stagingQueue": {
-    "current": 25,
-    "queue": [28],
-    "history": [17]
+    "current": 28,
+    "queue": [],
+    "history": [17, 25]
   },
-  "nextAction": "Epic #28 merged to develop for staging. Epic #25 promotion — PR #76 ready, 3 green days, awaiting user merge approval. After #25 promotes, #28 bake period begins. Issue #21 (i18n) groomed and ready for planning."
+  "nextAction": "Epic #28 STAGED on develop and baking (day 0/3). First regression run needed. Epic #25 promoted to production. Issue #21 (i18n) groomed with 6 sub-issues (#87-#92) ready for planning when prioritized."
 }

--- a/.github/TL_STATE.json
+++ b/.github/TL_STATE.json
@@ -3,21 +3,21 @@
   "repo": "math-trainer",
   "projectNumber": 6,
   "projectId": "PVT_kwHOA54Ghc4BQtkw",
-  "currentPhase": "execute",
-  "currentStep": "3.4",
+  "currentPhase": "epic-complete",
+  "currentStep": "3.9",
   "currentIssue": 28,
-  "currentSubIssue": 77,
-  "currentPR": 82,
-  "currentBranch": "feature/77-wire-current-level",
+  "currentSubIssue": null,
+  "currentPR": null,
+  "currentBranch": "epic/28-level-progression-ui",
   "executionPlan": {
     "epicBranch": "epic/28-level-progression-ui",
     "groups": [
-      {"group": 1, "subIssues": [77], "parallel": false, "agent": "react-specialist", "status": "pending"},
-      {"group": 2, "subIssues": [78, 80], "parallel": true, "agent": "react-specialist", "status": "pending"},
-      {"group": 3, "subIssues": [79], "parallel": false, "agent": "react-specialist", "status": "pending"},
-      {"group": 4, "subIssues": [81], "parallel": false, "agent": "react-specialist", "status": "pending"}
+      {"group": 1, "subIssues": [77], "parallel": false, "agent": "react-specialist", "status": "complete"},
+      {"group": 2, "subIssues": [78, 80], "parallel": true, "agent": "react-specialist", "status": "complete"},
+      {"group": 3, "subIssues": [79], "parallel": false, "agent": "react-specialist", "status": "complete"},
+      {"group": 4, "subIssues": [81], "parallel": false, "agent": "react-specialist", "status": "complete"}
     ],
-    "currentGroup": 1,
+    "currentGroup": 4,
     "currentSubIssueIndex": 0
   },
   "lastCompact": "2026-03-09T12:00:00Z",
@@ -104,7 +104,7 @@
       "title": "Phase 6 — Learning Aids",
       "promotionPR": 76,
       "bakeStartDate": "2026-03-09",
-      "consecutiveGreenDays": 0,
+      "consecutiveGreenDays": 2,
       "status": "baking",
       "subIssues": [26, 27],
       "allSubIssuesClosed": true
@@ -114,15 +114,18 @@
   "bakePeriod": {
     "startDate": "2026-03-09",
     "epicIssueNumber": 25,
-    "dailyResults": [],
-    "consecutiveGreenDays": 0,
+    "dailyResults": [
+      {"date": "2026-03-10", "result": "pass"},
+      {"date": "2026-03-11", "result": "pass"}
+    ],
+    "consecutiveGreenDays": 2,
     "status": "baking",
     "promotionPR": 76
   },
   "stagingQueue": {
     "current": 25,
-    "queue": [],
+    "queue": [28],
     "history": [17]
   },
-  "nextAction": "Step 3.2 — Implement sub-issue #77 (wire currentLevel) on branch feature/77-wire-current-level. PR #82 targeting epic branch."
+  "nextAction": "ALL 5 sub-issues COMPLETE. 719 tests. Epic branch ready. Step 3.9 — merge epic to develop for staging. Note: epic #25 is still baking on staging — #28 will queue behind it."
 }

--- a/.github/TL_STATE.json
+++ b/.github/TL_STATE.json
@@ -30,7 +30,7 @@
     {"phase": 1, "epicNumber": 11, "title": "Phase 1 — Level Config + Problem Generator", "priority": "P0", "subIssues": [12, 13], "status": "complete"},
     {"phase": 2, "epicNumber": 14, "title": "Phase 2 — Confidence Engine", "priority": "P0", "subIssues": [15, 16], "status": "complete"},
     {"phase": 3, "epicNumber": 17, "title": "Phase 3 — Multi-Profile System", "priority": "P0", "subIssues": [18, 19, 20], "issue19SubIssues": [53, 54, 55], "status": "complete"},
-    {"phase": 4, "epicNumber": 21, "title": "Phase 4 — i18n Hebrew + English", "priority": "P1", "subIssues": [87, 88, 89, 90, 91, 92], "legacySubIssues": [22]},
+    {"phase": 4, "epicNumber": 21, "title": "Phase 4 — i18n Hebrew + English", "priority": "P1", "subIssues": [87, 88, 89, 90, 91, 92], "legacySubIssues": [22], "status": "epic-complete"},
     {"phase": 5, "epicNumber": 23, "title": "Phase 5 — Superhero Theme System", "priority": "P1", "subIssues": [24]},
     {"phase": 6, "epicNumber": 25, "title": "Phase 6 — Learning Aids", "priority": "P0", "subIssues": [26, 27], "status": "promoted"},
     {"phase": 7, "epicNumber": 28, "title": "Phase 7 — Level Progression UI", "priority": "P0", "subIssues": [77, 78, 79, 80, 81], "legacySubIssues": [29, 30], "status": "baking"},
@@ -85,7 +85,13 @@
     {"issueNumber": 78, "prNumber": 84, "completedAt": "2026-03-11", "note": "Level-up celebration screen — 35 new tests"},
     {"issueNumber": 80, "prNumber": 83, "completedAt": "2026-03-11", "note": "Level map progress visualization — 26 new tests"},
     {"issueNumber": 79, "prNumber": 85, "completedAt": "2026-03-11", "note": "Max-level champion screen — 11 new tests, 697 total"},
-    {"issueNumber": 81, "prNumber": 86, "completedAt": "2026-03-11", "note": "Integration tests — 22 tests, 719 total"}
+    {"issueNumber": 81, "prNumber": 86, "completedAt": "2026-03-11", "note": "Integration tests — 22 tests, 719 total"},
+    {"issueNumber": 87, "prNumber": 95, "completedAt": "2026-03-12", "note": "i18n infrastructure — 43 new tests, 762 total"},
+    {"issueNumber": 88, "prNumber": 96, "completedAt": "2026-03-12", "note": "Language switching + RTL — 15 new tests, 777 total"},
+    {"issueNumber": 89, "prNumber": 98, "completedAt": "2026-03-12", "note": "Core screen string externalization"},
+    {"issueNumber": 90, "prNumber": 97, "completedAt": "2026-03-12", "note": "Profile component string externalization + RTL fixes"},
+    {"issueNumber": 91, "prNumber": 99, "completedAt": "2026-03-12", "note": "Strategy engine i18n — {key,params} objects, +1 test, 778 total"},
+    {"issueNumber": 92, "prNumber": 100, "completedAt": "2026-03-12", "note": "Integration tests — 42 new tests, 820 total"}
   ],
   "completedEpics": [
     {"epicNumber": 11, "title": "Phase 1 — Level Config + Problem Generator", "completedAt": "2026-03-08"},
@@ -134,8 +140,8 @@
   },
   "stagingQueue": {
     "current": 28,
-    "queue": [],
+    "queue": [21],
     "history": [17, 25]
   },
-  "nextAction": "Epic #28 STAGED on develop and baking (day 0/3). First regression run needed. Epic #25 promoted to production. Issue #21 (i18n) groomed with 6 sub-issues (#87-#92) ready for planning when prioritized."
+  "nextAction": "Epic #21 COMPLETE on epic branch (6/6 sub-issues, 820 tests). Queued behind #28 in staging. Epic #28 baking on staging (day 0/3). After #28 promotes, #21 can stage. Next grooming: #24 (Superhero Theme)."
 }

--- a/.github/TL_STATE.json
+++ b/.github/TL_STATE.json
@@ -4,11 +4,11 @@
   "projectNumber": 6,
   "projectId": "PVT_kwHOA54Ghc4BQtkw",
   "currentPhase": "execute",
-  "currentStep": "3.1",
+  "currentStep": "3.4",
   "currentIssue": 28,
-  "currentSubIssue": null,
-  "currentPR": null,
-  "currentBranch": "develop",
+  "currentSubIssue": 77,
+  "currentPR": 82,
+  "currentBranch": "feature/77-wire-current-level",
   "executionPlan": {
     "epicBranch": "epic/28-level-progression-ui",
     "groups": [
@@ -124,5 +124,5 @@
     "queue": [],
     "history": [17]
   },
-  "nextAction": "Phase 2 COMPLETE. Execution plan saved. Starting Phase 3 — create epic branch + begin Group 1 (sub-issue #77: wire currentLevel)."
+  "nextAction": "Step 3.2 — Implement sub-issue #77 (wire currentLevel) on branch feature/77-wire-current-level. PR #82 targeting epic branch."
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,6 +2,7 @@ import { useState, useCallback } from 'react'
 import { useFirebase, useGameProgress } from './hooks'
 import { StartScreen, GameScreen, ResultScreen, LevelUpScreen, ProfileSwitcher, CreateProfile } from './components'
 import { useProfile } from './context/useProfile'
+import { MAX_LEVEL } from './config/levels'
 
 /**
  * App Component - Main application with screen navigation
@@ -136,8 +137,8 @@ function App() {
   const handleContinueAfterLevelUp = useCallback(() => {
     if (completedLevel !== null && activeProfile) {
       const nextLevel = completedLevel + 1
-      // Max level guard: do not update profile beyond LEVELS.length (13)
-      if (nextLevel <= 13) {
+      // Max level guard: do not update profile beyond MAX_LEVEL
+      if (nextLevel <= MAX_LEVEL) {
         updateProfile(activeProfile.id, { currentLevel: nextLevel })
       }
     }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -219,6 +219,7 @@ function App() {
           progress={progress}
           onSwitchProfile={handleSwitchProfile}
           activeProfile={activeProfile}
+          currentLevel={currentLevel}
         />
       )}
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,6 @@
 import { useState, useCallback } from 'react'
 import { useFirebase, useGameProgress } from './hooks'
-import { StartScreen, GameScreen, ResultScreen, ProfileSwitcher, CreateProfile } from './components'
+import { StartScreen, GameScreen, ResultScreen, LevelUpScreen, ProfileSwitcher, CreateProfile } from './components'
 import { useProfile } from './context/useProfile'
 
 /**
@@ -15,18 +15,24 @@ import { useProfile } from './context/useProfile'
  *                                      |
  *                                      v (onComplete)
  * [activeProfile set]             -> StartScreen -> GameScreen -> ResultScreen
- *                                      ^            |              |
- *                                      +------------+--------------+
+ *                                      ^            |    |         |
+ *                                      +------------+----+---------+
+ *                                                   |
+ *                                                   v (shouldLevelUp)
+ *                                               LevelUpScreen
+ *                                                   |
+ *                                                   v (Continue)
+ *                                               GameScreen (next level)
  *
  * Manages:
  * - Profile-gated entry: shows ProfileSwitcher or CreateProfile when no active profile
- * - Screen state ('start', 'game', 'result')
+ * - Screen state ('start', 'game', 'result', 'levelup')
  * - Firebase authentication
  * - Game progress persistence (keyed to activeProfile.firebaseUid)
  * - Session statistics between screens
  */
 function App() {
-  const { activeProfile, isLoading: profileLoading, clearActiveProfile, createAndActivate } = useProfile()
+  const { activeProfile, isLoading: profileLoading, clearActiveProfile, createAndActivate, updateProfile } = useProfile()
   const { user, loading: authLoading, error: authError } = useFirebase()
   const {
     progress,
@@ -46,6 +52,9 @@ function App() {
 
   // Whether to show CreateProfile wizard (when no active profile)
   const [showCreate, setShowCreate] = useState(false)
+
+  // Track which level was just completed (for LevelUpScreen)
+  const [completedLevel, setCompletedLevel] = useState(null)
 
   // Combine loading states
   const loading = profileLoading || authLoading || progressLoading
@@ -116,6 +125,25 @@ function App() {
   const handleCreateCancel = useCallback(() => {
     setShowCreate(false)
   }, [])
+
+  // Handle level-up detection from GameScreen
+  const handleLevelUp = useCallback((level) => {
+    setCompletedLevel(level)
+    setScreen('levelup')
+  }, [])
+
+  // Handle continue after level-up celebration
+  const handleContinueAfterLevelUp = useCallback(() => {
+    if (completedLevel !== null && activeProfile) {
+      const nextLevel = completedLevel + 1
+      // Max level guard: do not update profile beyond LEVELS.length (13)
+      if (nextLevel <= 13) {
+        updateProfile(activeProfile.id, { currentLevel: nextLevel })
+      }
+    }
+    setCompletedLevel(null)
+    setScreen('game')
+  }, [completedLevel, activeProfile, updateProfile])
 
   // Show loading state while authenticating or loading progress
   if (loading) {
@@ -200,6 +228,14 @@ function App() {
           updateProgress={updateProgress}
           initialProgress={progress}
           currentLevel={currentLevel}
+          onLevelUp={handleLevelUp}
+        />
+      )}
+
+      {screen === 'levelup' && completedLevel !== null && (
+        <LevelUpScreen
+          completedLevel={completedLevel}
+          onContinue={handleContinueAfterLevelUp}
         />
       )}
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -35,6 +35,9 @@ function App() {
     loading: progressLoading,
   } = useGameProgress(activeProfile?.firebaseUid ?? user?.uid)
 
+  // Extract currentLevel from active profile (default to 1 when no profile)
+  const currentLevel = activeProfile?.currentLevel ?? 1
+
   // Screen navigation state
   const [screen, setScreen] = useState('start')
 
@@ -196,6 +199,7 @@ function App() {
           onGameEnd={handleGameEnd}
           updateProgress={updateProgress}
           initialProgress={progress}
+          currentLevel={currentLevel}
         />
       )}
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -231,6 +231,7 @@ function App() {
           initialProgress={progress}
           currentLevel={currentLevel}
           onLevelUp={handleLevelUp}
+          activeProfile={activeProfile}
         />
       )}
 
@@ -246,6 +247,7 @@ function App() {
           sessionStats={sessionStats}
           onPlayAgain={handlePlayAgain}
           onExit={handleExit}
+          theme={activeProfile?.theme}
         />
       )}
     </>

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -13,6 +13,7 @@ const mockProfileContext = {
   isLoading: false,
   clearActiveProfile: vi.fn(),
   createAndActivate: vi.fn(),
+  updateProfile: vi.fn(),
 }
 
 vi.mock('./context/useProfile', () => ({
@@ -43,7 +44,7 @@ vi.mock('./components', () => ({
       createElement('button', { 'data-testid': 'start-game', onClick: onStart }, 'Start'),
       createElement('button', { 'data-testid': 'switch-profile', onClick: onSwitchProfile }, 'Switch'),
     ),
-  GameScreen: ({ onGameEnd, currentLevel }) =>
+  GameScreen: ({ onGameEnd, currentLevel, onLevelUp }) =>
     createElement('div', { 'data-testid': 'game-screen', 'data-current-level': currentLevel },
       createElement('button', {
         'data-testid': 'end-game',
@@ -53,11 +54,19 @@ vi.mock('./components', () => ({
         'data-testid': 'exit-game',
         onClick: () => onGameEnd(null),
       }, 'Exit'),
+      createElement('button', {
+        'data-testid': 'trigger-level-up',
+        onClick: () => onLevelUp(currentLevel),
+      }, 'Level Up'),
     ),
   ResultScreen: ({ onPlayAgain, onExit }) =>
     createElement('div', { 'data-testid': 'result-screen' },
       createElement('button', { 'data-testid': 'play-again', onClick: onPlayAgain }, 'Play Again'),
       createElement('button', { 'data-testid': 'exit-result', onClick: onExit }, 'Exit'),
+    ),
+  LevelUpScreen: ({ completedLevel, onContinue }) =>
+    createElement('div', { 'data-testid': 'levelup-screen', 'data-completed-level': completedLevel },
+      createElement('button', { 'data-testid': 'continue-level-up', onClick: onContinue }, 'Continue'),
     ),
   ProfileSwitcher: ({ onCreateProfile }) =>
     createElement('div', { 'data-testid': 'profile-switcher' },
@@ -93,6 +102,7 @@ describe('App', () => {
     mockProfileContext.isLoading = false
     mockProfileContext.clearActiveProfile = vi.fn()
     mockProfileContext.createAndActivate = vi.fn()
+    mockProfileContext.updateProfile = vi.fn()
     mockFirebase.user = { uid: 'test-uid' }
     mockFirebase.loading = false
     mockFirebase.error = null
@@ -418,6 +428,113 @@ describe('App', () => {
 
       const gameScreen = screen.getByTestId('game-screen')
       expect(gameScreen.getAttribute('data-current-level')).toBe('13')
+    })
+  })
+
+  // ── Level-up flow ──────────────────────────────────────────────────
+
+  describe('level-up flow', () => {
+    it('transitions from game to levelup screen when onLevelUp is called', () => {
+      mockProfileContext.activeProfile = {
+        id: '1',
+        nickname: 'Dubi',
+        firebaseUid: 'uid-1',
+        currentLevel: 3,
+      }
+      render(<App />)
+
+      // Navigate to game
+      fireEvent.click(screen.getByTestId('start-game'))
+      expect(screen.getByTestId('game-screen')).toBeTruthy()
+
+      // Trigger level up
+      fireEvent.click(screen.getByTestId('trigger-level-up'))
+
+      // Should show level-up screen
+      expect(screen.getByTestId('levelup-screen')).toBeTruthy()
+      expect(screen.queryByTestId('game-screen')).toBeNull()
+    })
+
+    it('passes completedLevel to LevelUpScreen', () => {
+      mockProfileContext.activeProfile = {
+        id: '1',
+        nickname: 'Dubi',
+        firebaseUid: 'uid-1',
+        currentLevel: 5,
+      }
+      render(<App />)
+
+      fireEvent.click(screen.getByTestId('start-game'))
+      fireEvent.click(screen.getByTestId('trigger-level-up'))
+
+      const levelUpScreen = screen.getByTestId('levelup-screen')
+      expect(levelUpScreen.getAttribute('data-completed-level')).toBe('5')
+    })
+
+    it('transitions back to game screen when continue is clicked', () => {
+      mockProfileContext.activeProfile = {
+        id: '1',
+        nickname: 'Dubi',
+        firebaseUid: 'uid-1',
+        currentLevel: 3,
+      }
+      render(<App />)
+
+      // Navigate: start -> game -> levelup
+      fireEvent.click(screen.getByTestId('start-game'))
+      fireEvent.click(screen.getByTestId('trigger-level-up'))
+      expect(screen.getByTestId('levelup-screen')).toBeTruthy()
+
+      // Continue -> back to game
+      fireEvent.click(screen.getByTestId('continue-level-up'))
+      expect(screen.getByTestId('game-screen')).toBeTruthy()
+      expect(screen.queryByTestId('levelup-screen')).toBeNull()
+    })
+
+    it('calls updateProfile with currentLevel+1 when continue is clicked', () => {
+      mockProfileContext.activeProfile = {
+        id: '1',
+        nickname: 'Dubi',
+        firebaseUid: 'uid-1',
+        currentLevel: 3,
+      }
+      render(<App />)
+
+      fireEvent.click(screen.getByTestId('start-game'))
+      fireEvent.click(screen.getByTestId('trigger-level-up'))
+      fireEvent.click(screen.getByTestId('continue-level-up'))
+
+      expect(mockProfileContext.updateProfile).toHaveBeenCalledTimes(1)
+      expect(mockProfileContext.updateProfile).toHaveBeenCalledWith('1', { currentLevel: 4 })
+    })
+
+    it('does NOT call updateProfile with currentLevel 14 when at max level (13)', () => {
+      mockProfileContext.activeProfile = {
+        id: '1',
+        nickname: 'Dubi',
+        firebaseUid: 'uid-1',
+        currentLevel: 13,
+      }
+      render(<App />)
+
+      fireEvent.click(screen.getByTestId('start-game'))
+      fireEvent.click(screen.getByTestId('trigger-level-up'))
+      fireEvent.click(screen.getByTestId('continue-level-up'))
+
+      // Should NOT update profile to level 14
+      expect(mockProfileContext.updateProfile).not.toHaveBeenCalledWith('1', { currentLevel: 14 })
+    })
+
+    it('does not show levelup screen on initial render', () => {
+      mockProfileContext.activeProfile = {
+        id: '1',
+        nickname: 'Dubi',
+        firebaseUid: 'uid-1',
+        currentLevel: 1,
+      }
+      render(<App />)
+
+      expect(screen.queryByTestId('levelup-screen')).toBeNull()
     })
   })
 })

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -7,6 +7,11 @@ import { createElement } from 'react'
 
 // ─── Mocks ────────────────────────────────────────────────────────────────────
 
+// Mock levels config (App imports MAX_LEVEL)
+vi.mock('./config/levels', () => ({
+  MAX_LEVEL: 13,
+}))
+
 // Mock useProfile hook
 const mockProfileContext = {
   activeProfile: null,

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -43,8 +43,8 @@ vi.mock('./components', () => ({
       createElement('button', { 'data-testid': 'start-game', onClick: onStart }, 'Start'),
       createElement('button', { 'data-testid': 'switch-profile', onClick: onSwitchProfile }, 'Switch'),
     ),
-  GameScreen: ({ onGameEnd }) =>
-    createElement('div', { 'data-testid': 'game-screen' },
+  GameScreen: ({ onGameEnd, currentLevel }) =>
+    createElement('div', { 'data-testid': 'game-screen', 'data-current-level': currentLevel },
       createElement('button', {
         'data-testid': 'end-game',
         onClick: () => onGameEnd({ score: 10, streak: 3, totalProblems: 5, correctAnswers: 4 }),
@@ -354,6 +354,70 @@ describe('App', () => {
       render(<App />)
 
       expect(screen.getByText('Play Anyway!')).toBeTruthy()
+    })
+  })
+
+  // ── currentLevel prop threading ───────────────────────────────────────
+
+  describe('currentLevel prop threading', () => {
+    it('passes activeProfile.currentLevel to GameScreen', () => {
+      mockProfileContext.activeProfile = {
+        id: '1',
+        nickname: 'Dubi',
+        firebaseUid: 'uid-1',
+        currentLevel: 5,
+      }
+      render(<App />)
+
+      // Navigate to game screen
+      fireEvent.click(screen.getByTestId('start-game'))
+
+      const gameScreen = screen.getByTestId('game-screen')
+      expect(gameScreen.getAttribute('data-current-level')).toBe('5')
+    })
+
+    it('defaults currentLevel to 1 when activeProfile has no currentLevel', () => {
+      mockProfileContext.activeProfile = {
+        id: '1',
+        nickname: 'Dubi',
+        firebaseUid: 'uid-1',
+      }
+      render(<App />)
+
+      fireEvent.click(screen.getByTestId('start-game'))
+
+      const gameScreen = screen.getByTestId('game-screen')
+      expect(gameScreen.getAttribute('data-current-level')).toBe('1')
+    })
+
+    it('passes currentLevel 1 when activeProfile.currentLevel is explicitly 1', () => {
+      mockProfileContext.activeProfile = {
+        id: '1',
+        nickname: 'Dubi',
+        firebaseUid: 'uid-1',
+        currentLevel: 1,
+      }
+      render(<App />)
+
+      fireEvent.click(screen.getByTestId('start-game'))
+
+      const gameScreen = screen.getByTestId('game-screen')
+      expect(gameScreen.getAttribute('data-current-level')).toBe('1')
+    })
+
+    it('passes high currentLevel (13) through to GameScreen', () => {
+      mockProfileContext.activeProfile = {
+        id: '1',
+        nickname: 'Dubi',
+        firebaseUid: 'uid-1',
+        currentLevel: 13,
+      }
+      render(<App />)
+
+      fireEvent.click(screen.getByTestId('start-game'))
+
+      const gameScreen = screen.getByTestId('game-screen')
+      expect(gameScreen.getAttribute('data-current-level')).toBe('13')
     })
   })
 })

--- a/src/components/CreateProfile.jsx
+++ b/src/components/CreateProfile.jsx
@@ -534,6 +534,7 @@ function CreateProfile({ onComplete, onCancel }) {
   /** Step 3: PIN entry */
   const renderPinStep = () => (
     <PinEntry
+      key="pin-set"
       profileName="Choose a secret PIN"
       onSubmit={handlePinSet}
       onCancel={handleBack}
@@ -548,6 +549,7 @@ function CreateProfile({ onComplete, onCancel }) {
   /** Step 4: PIN confirmation */
   const renderPinConfirmStep = () => (
     <PinEntry
+      key="pin-confirm"
       profileName="Confirm your PIN"
       onSubmit={handlePinConfirm}
       onCancel={handleBack}

--- a/src/components/CreateProfile.test.jsx
+++ b/src/components/CreateProfile.test.jsx
@@ -88,9 +88,6 @@ async function goToStep4(name = 'TestHero', pin = '1234') {
   completeThemeStep()
   enterPin(pin)
   await flush()
-  // PinEntry reconciles from step 3 to step 4 -- digits carry over.
-  // Clear them with backspace so the step-4 PinEntry is ready for input.
-  clearPinDigits()
 }
 
 /**
@@ -110,21 +107,6 @@ async function enterMismatchedPinAndFlush(pin = '9999') {
   mockHashPin.mockResolvedValueOnce('different-hash')
   enterPin(pin)
   await flush()
-}
-
-/**
- * Clear all 4 digits in the PinEntry via backspace button.
- * After step 3 -> step 4 reconciliation, digits carry over and
- * must be cleared before entering the confirmation PIN.
- */
-function clearPinDigits() {
-  const backspaceBtn = screen.queryByLabelText('Delete last digit')
-  if (!backspaceBtn) return
-  for (let i = 0; i < 4; i++) {
-    if (!backspaceBtn.disabled) {
-      fireEvent.click(backspaceBtn)
-    }
-  }
 }
 
 // ─── Tests ───────────────────────────────────────────────────────────────────
@@ -766,8 +748,7 @@ describe('CreateProfile', () => {
       await flush()
       expect(screen.getByText('Confirm your PIN')).toBeTruthy()
 
-      // Step 4: confirm PIN (clear stale digits from step 3 first)
-      clearPinDigits()
+      // Step 4: confirm PIN
       mockHashPin.mockResolvedValueOnce('hash-abc')
       enterPin('1234')
       await flush()
@@ -803,8 +784,7 @@ describe('CreateProfile', () => {
       mockHashPin.mockResolvedValueOnce('new-hash-5555')
       enterPin('5555')
       await flush()
-      // On step 4 with new hash -- clear stale digits from step 3
-      clearPinDigits()
+      // On step 4 with new hash
       // Confirm with new matching hash
       mockHashPin.mockResolvedValueOnce('new-hash-5555')
       enterPin('5555')

--- a/src/components/Feedback.jsx
+++ b/src/components/Feedback.jsx
@@ -1,26 +1,28 @@
 import { useEffect, useState, useCallback } from 'react'
 import PropTypes from 'prop-types'
+import { getTheme } from '../config/themes'
 
 /**
  * Feedback Component
  *
  * Shows animated visual feedback after answer submission.
- * Designed for a 7-year-old with Sonic theming - fun and encouraging!
+ * Designed for a 7-year-old with hero theming - fun and encouraging!
  *
  * @param {boolean} isCorrect - Whether the answer was correct
  * @param {function} onComplete - Callback when animation finishes
+ * @param {string} theme - Theme key (e.g. 'sonic', 'spiderman')
  */
 
-// Correct answer messages - exciting and rewarding!
-const CORRECT_MESSAGES = [
-  { text: 'Sonic Speed!', emoji: '🦔💨' },
-  { text: 'Amazing!', emoji: '⭐' },
-  { text: 'Perfect!', emoji: '🎯' },
-  { text: 'Great Job!', emoji: '🎉' },
-  { text: "You're on Fire!", emoji: '🔥' },
-  { text: 'Super Star!', emoji: '🌟' },
-  { text: 'Awesome!', emoji: '✨' },
-  { text: 'Incredible!', emoji: '💫' },
+// Build correct-answer messages themed to the active hero
+const getCorrectMessages = (themeObj) => [
+  { text: themeObj.correctMessage, emoji: themeObj.emoji },
+  { text: 'Amazing!', emoji: '\u{2B50}' },
+  { text: 'Perfect!', emoji: '\u{1F3AF}' },
+  { text: 'Great Job!', emoji: '\u{1F389}' },
+  { text: "You're on Fire!", emoji: '\u{1F525}' },
+  { text: 'Super Star!', emoji: '\u{1F31F}' },
+  { text: 'Awesome!', emoji: '\u{2728}' },
+  { text: 'Incredible!', emoji: '\u{1F4AB}' },
 ]
 
 // Wrong answer messages - gentle and encouraging!
@@ -38,17 +40,18 @@ const FADE_IN_DURATION = 200
 const SHOW_DURATION = 1500
 const FADE_OUT_DURATION = 200
 
-function Feedback({ isCorrect, onComplete = null }) {
+function Feedback({ isCorrect, onComplete = null, theme: themeKey = null }) {
+  const themeObj = getTheme(themeKey)
   const [visible, setVisible] = useState(false)
   const [fadeOut, setFadeOut] = useState(false)
   const [message, setMessage] = useState({ text: '', emoji: '' })
 
   // Pick a random message based on correctness
   const pickMessage = useCallback(() => {
-    const messages = isCorrect ? CORRECT_MESSAGES : WRONG_MESSAGES
+    const messages = isCorrect ? getCorrectMessages(themeObj) : WRONG_MESSAGES
     const randomIndex = Math.floor(Math.random() * messages.length)
     return messages[randomIndex]
-  }, [isCorrect])
+  }, [isCorrect, themeObj])
 
   useEffect(() => {
     // Pick message and start animation
@@ -151,6 +154,7 @@ function Feedback({ isCorrect, onComplete = null }) {
 Feedback.propTypes = {
   isCorrect: PropTypes.bool.isRequired,
   onComplete: PropTypes.func,
+  theme: PropTypes.string,
 }
 
 export default Feedback

--- a/src/components/GameScreen.jsx
+++ b/src/components/GameScreen.jsx
@@ -23,8 +23,9 @@ import { useGameState } from '../hooks'
  * @param {object} initialProgress - Optional initial progress from Firestore
  * @param {number} currentLevel - Current difficulty level (1-13, default 1)
  * @param {function} onLevelUp - Optional callback when confidence engine signals level-up
+ * @param {object} activeProfile - Optional active profile (provides theme)
  */
-function GameScreen({ onGameEnd, updateProgress = null, initialProgress = null, currentLevel = 1, onLevelUp }) {
+function GameScreen({ onGameEnd, updateProgress = null, initialProgress = null, currentLevel = 1, onLevelUp, activeProfile = null }) {
   const {
     currentProblem,
     score,
@@ -86,7 +87,7 @@ function GameScreen({ onGameEnd, updateProgress = null, initialProgress = null, 
       <header className="flex justify-between items-start gap-4 mb-6 md:mb-8">
         {/* Score Display */}
         <div className="flex-1">
-          <ScoreDisplay score={score} streak={streak} />
+          <ScoreDisplay score={score} streak={streak} theme={activeProfile?.theme} />
         </div>
 
         {/* Exit Button */}
@@ -143,7 +144,7 @@ function GameScreen({ onGameEnd, updateProgress = null, initialProgress = null, 
 
       {/* Feedback Overlay - Shows on answer */}
       {showFeedback && (
-        <Feedback isCorrect={isCorrect} />
+        <Feedback isCorrect={isCorrect} theme={activeProfile?.theme} />
       )}
     </div>
   )
@@ -160,6 +161,9 @@ GameScreen.propTypes = {
   }),
   currentLevel: PropTypes.number,
   onLevelUp: PropTypes.func,
+  activeProfile: PropTypes.shape({
+    theme: PropTypes.string,
+  }),
 }
 
 export default GameScreen

--- a/src/components/GameScreen.jsx
+++ b/src/components/GameScreen.jsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react'
 import PropTypes from 'prop-types'
 import { Problem, AnswerButtons, ScoreDisplay, Feedback } from './index'
 import { LearningAid } from './aids'
@@ -21,8 +22,9 @@ import { useGameState } from '../hooks'
  * @param {function} updateProgress - Optional callback for Firestore persistence
  * @param {object} initialProgress - Optional initial progress from Firestore
  * @param {number} currentLevel - Current difficulty level (1-13, default 1)
+ * @param {function} onLevelUp - Optional callback when confidence engine signals level-up
  */
-function GameScreen({ onGameEnd, updateProgress = null, initialProgress = null, currentLevel = 1 }) {
+function GameScreen({ onGameEnd, updateProgress = null, initialProgress = null, currentLevel = 1, onLevelUp }) {
   const {
     currentProblem,
     score,
@@ -37,7 +39,17 @@ function GameScreen({ onGameEnd, updateProgress = null, initialProgress = null, 
     correctAnswers,
     accuracy,
     isStruggling,
+    shouldLevelUp,
   } = useGameState({ currentLevel, updateProgress, initialProgress })
+
+  // Detect level-up: when confidence engine signals shouldLevelUp AND feedback
+  // animation has cleared, notify the parent (App) to transition to LevelUpScreen.
+  // The parent unmounts GameScreen, so no race condition with auto-advance.
+  useEffect(() => {
+    if (shouldLevelUp && !showFeedback && onLevelUp) {
+      onLevelUp(currentLevel)
+    }
+  }, [shouldLevelUp, showFeedback, onLevelUp, currentLevel])
 
   // Start game automatically if not playing
   // This handles the initial mount
@@ -147,6 +159,7 @@ GameScreen.propTypes = {
     correctAnswers: PropTypes.number,
   }),
   currentLevel: PropTypes.number,
+  onLevelUp: PropTypes.func,
 }
 
 export default GameScreen

--- a/src/components/GameScreen.jsx
+++ b/src/components/GameScreen.jsx
@@ -20,8 +20,9 @@ import { useGameState } from '../hooks'
  * @param {function} onGameEnd - Callback when user exits the game
  * @param {function} updateProgress - Optional callback for Firestore persistence
  * @param {object} initialProgress - Optional initial progress from Firestore
+ * @param {number} currentLevel - Current difficulty level (1-13, default 1)
  */
-function GameScreen({ onGameEnd, updateProgress = null, initialProgress = null }) {
+function GameScreen({ onGameEnd, updateProgress = null, initialProgress = null, currentLevel = 1 }) {
   const {
     currentProblem,
     score,
@@ -36,7 +37,7 @@ function GameScreen({ onGameEnd, updateProgress = null, initialProgress = null }
     correctAnswers,
     accuracy,
     isStruggling,
-  } = useGameState({ updateProgress, initialProgress })
+  } = useGameState({ currentLevel, updateProgress, initialProgress })
 
   // Start game automatically if not playing
   // This handles the initial mount
@@ -109,7 +110,7 @@ function GameScreen({ onGameEnd, updateProgress = null, initialProgress = null }
         <LearningAid
           key={totalProblems}
           isStruggling={isStruggling}
-          currentLevel={2}
+          currentLevel={currentLevel}
           num1={currentProblem.num1}
           num2={currentProblem.num2}
           operator={currentProblem.operator}
@@ -145,6 +146,7 @@ GameScreen.propTypes = {
     totalProblems: PropTypes.number,
     correctAnswers: PropTypes.number,
   }),
+  currentLevel: PropTypes.number,
 }
 
 export default GameScreen

--- a/src/components/GameScreen.test.jsx
+++ b/src/components/GameScreen.test.jsx
@@ -1,0 +1,171 @@
+/**
+ * @vitest-environment happy-dom
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, act, cleanup } from '@testing-library/react'
+import { createElement } from 'react'
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+
+// Mock useGameState hook with controllable state
+const mockGameState = {
+  currentProblem: { num1: 3, num2: 2, operator: '+', correctAnswer: 5, options: [3, 4, 5, 6] },
+  score: 0,
+  streak: 0,
+  bestStreak: 0,
+  showFeedback: false,
+  isCorrect: false,
+  handleAnswer: vi.fn(),
+  startGame: vi.fn(),
+  isPlaying: true,
+  totalProblems: 0,
+  correctAnswers: 0,
+  accuracy: 0,
+  isStruggling: false,
+  shouldLevelUp: false,
+}
+
+vi.mock('../hooks', () => ({
+  useGameState: () => mockGameState,
+}))
+
+// Mock child components (Problem, AnswerButtons, ScoreDisplay, Feedback)
+vi.mock('./index', () => ({
+  Problem: ({ num1, num2, operator }) =>
+    createElement('div', { 'data-testid': 'problem' }, `${num1} ${operator} ${num2}`),
+  AnswerButtons: ({ options, onAnswer, disabled }) =>
+    createElement('div', { 'data-testid': 'answer-buttons' },
+      options.map((opt) =>
+        createElement('button', {
+          key: opt,
+          'data-testid': `answer-${opt}`,
+          onClick: () => onAnswer(opt),
+          disabled,
+        }, opt)
+      )
+    ),
+  ScoreDisplay: ({ score, streak }) =>
+    createElement('div', { 'data-testid': 'score-display' }, `Score: ${score} Streak: ${streak}`),
+  Feedback: ({ isCorrect }) =>
+    createElement('div', { 'data-testid': 'feedback' }, isCorrect ? 'Correct!' : 'Wrong!'),
+}))
+
+// Mock LearningAid
+vi.mock('./aids', () => ({
+  LearningAid: () => createElement('div', { 'data-testid': 'learning-aid' }),
+}))
+
+// Import after mocks
+const { default: GameScreen } = await import('./GameScreen')
+
+describe('GameScreen', () => {
+  const defaultProps = {
+    onGameEnd: vi.fn(),
+    updateProgress: vi.fn(),
+    initialProgress: null,
+    currentLevel: 1,
+    onLevelUp: vi.fn(),
+  }
+
+  beforeEach(() => {
+    cleanup()
+    vi.clearAllMocks()
+    // Reset mock state to defaults
+    mockGameState.currentProblem = { num1: 3, num2: 2, operator: '+', correctAnswer: 5, options: [3, 4, 5, 6] }
+    mockGameState.score = 0
+    mockGameState.streak = 0
+    mockGameState.bestStreak = 0
+    mockGameState.showFeedback = false
+    mockGameState.isCorrect = false
+    mockGameState.isPlaying = true
+    mockGameState.totalProblems = 0
+    mockGameState.correctAnswers = 0
+    mockGameState.accuracy = 0
+    mockGameState.isStruggling = false
+    mockGameState.shouldLevelUp = false
+  })
+
+  // ── Basic rendering ────────────────────────────────────────────────
+
+  describe('basic rendering', () => {
+    it('renders the game screen with problem and answers', () => {
+      render(<GameScreen {...defaultProps} />)
+      expect(screen.getByTestId('problem')).toBeTruthy()
+      expect(screen.getByTestId('answer-buttons')).toBeTruthy()
+    })
+
+    it('renders exit button', () => {
+      render(<GameScreen {...defaultProps} />)
+      expect(screen.getByLabelText('Exit game and return to start screen')).toBeTruthy()
+    })
+
+    it('calls startGame when not playing', () => {
+      mockGameState.isPlaying = false
+      render(<GameScreen {...defaultProps} />)
+      expect(mockGameState.startGame).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  // ── shouldLevelUp detection ────────────────────────────────────────
+
+  describe('shouldLevelUp detection', () => {
+    it('calls onLevelUp when shouldLevelUp is true and showFeedback is false', () => {
+      mockGameState.shouldLevelUp = true
+      mockGameState.showFeedback = false
+
+      render(<GameScreen {...defaultProps} currentLevel={3} />)
+
+      expect(defaultProps.onLevelUp).toHaveBeenCalledTimes(1)
+      expect(defaultProps.onLevelUp).toHaveBeenCalledWith(3)
+    })
+
+    it('does NOT call onLevelUp when shouldLevelUp is false', () => {
+      mockGameState.shouldLevelUp = false
+      mockGameState.showFeedback = false
+
+      render(<GameScreen {...defaultProps} currentLevel={3} />)
+
+      expect(defaultProps.onLevelUp).not.toHaveBeenCalled()
+    })
+
+    it('does NOT call onLevelUp when showFeedback is true (waiting for feedback to clear)', () => {
+      mockGameState.shouldLevelUp = true
+      mockGameState.showFeedback = true
+
+      render(<GameScreen {...defaultProps} currentLevel={3} />)
+
+      expect(defaultProps.onLevelUp).not.toHaveBeenCalled()
+    })
+
+    it('does NOT call onLevelUp when onLevelUp prop is not provided', () => {
+      mockGameState.shouldLevelUp = true
+      mockGameState.showFeedback = false
+
+      // Should not throw
+      render(<GameScreen {...defaultProps} onLevelUp={undefined} />)
+    })
+  })
+
+  // ── Exit (onGameEnd) ──────────────────────────────────────────────
+
+  describe('exit button', () => {
+    it('calls onGameEnd with session stats when exit is clicked', () => {
+      mockGameState.score = 50
+      mockGameState.bestStreak = 3
+      mockGameState.totalProblems = 10
+      mockGameState.correctAnswers = 7
+      mockGameState.accuracy = 70
+
+      render(<GameScreen {...defaultProps} />)
+      fireEvent.click(screen.getByLabelText('Exit game and return to start screen'))
+
+      expect(defaultProps.onGameEnd).toHaveBeenCalledWith({
+        score: 50,
+        streak: 3,
+        totalProblems: 10,
+        correctAnswers: 7,
+        accuracy: 70,
+      })
+    })
+  })
+})

--- a/src/components/LevelMap.jsx
+++ b/src/components/LevelMap.jsx
@@ -1,0 +1,196 @@
+/**
+ * LevelMap -- Horizontal scrollable level progress visualization
+ *
+ * Displays 13 level checkpoints in a horizontal row.
+ * Each level shows its completion state:
+ *   - Completed (< currentLevel): green star
+ *   - Current (=== currentLevel): gold pulsing node
+ *   - Locked (> currentLevel): grey/faded lock
+ *
+ * Read-only for MVP -- no click-to-select.
+ * Auto-scrolls to show the current level on mount.
+ *
+ * @param {Object} props
+ * @param {number} [props.currentLevel=1] The player's current level (1-13)
+ */
+
+import { useRef, useEffect } from 'react'
+import PropTypes from 'prop-types'
+import LEVELS from '../config/levels'
+
+/**
+ * Returns the status of a level relative to the current level.
+ * @param {number} levelId
+ * @param {number} currentLevel
+ * @returns {'completed' | 'current' | 'locked'}
+ */
+function getLevelStatus(levelId, currentLevel) {
+  if (levelId < currentLevel) return 'completed'
+  if (levelId === currentLevel) return 'current'
+  return 'locked'
+}
+
+/**
+ * Single level node with icon, circle, and label.
+ */
+function LevelNode({ level, status, nodeRef }) {
+  const isCompleted = status === 'completed'
+  const isCurrent = status === 'current'
+  const isLocked = status === 'locked'
+
+  return (
+    <div
+      role="listitem"
+      aria-label={`Level ${level.id}: ${level.name} - ${status}`}
+      data-testid={`level-node-${level.id}`}
+      ref={nodeRef}
+      className="flex flex-col items-center snap-center shrink-0 w-16 md:w-20"
+    >
+      {/* Circle with icon */}
+      <div
+        className={`
+          flex items-center justify-center
+          w-10 h-10 md:w-12 md:h-12 rounded-full
+          border-2 transition-colors
+          ${isCompleted ? 'border-green-500 bg-green-500/20' : ''}
+          ${isCurrent ? 'border-yellow-500 bg-yellow-500/20' : ''}
+          ${isLocked ? 'border-gray-500 bg-gray-500/10 opacity-50' : ''}
+          ${isCurrent ? 'animate-pulse-gold motion-reduce:animate-none' : ''}
+        `}
+      >
+        {isCompleted && (
+          <span
+            className="text-green-500 text-lg md:text-xl"
+            data-testid="star-icon"
+            aria-hidden="true"
+          >
+            &#x2B50;
+          </span>
+        )}
+        {isCurrent && (
+          <span
+            className="text-yellow-500 text-lg md:text-xl font-game font-bold"
+            aria-hidden="true"
+          >
+            {level.id}
+          </span>
+        )}
+        {isLocked && (
+          <span
+            className="text-gray-400 text-lg md:text-xl"
+            data-testid="lock-icon"
+            aria-hidden="true"
+          >
+            &#x1F512;
+          </span>
+        )}
+      </div>
+
+      {/* Level name */}
+      <span
+        className={`
+          text-xs md:text-sm font-game text-center mt-1 leading-tight
+          ${isCompleted ? 'text-green-400' : ''}
+          ${isCurrent ? 'text-yellow-400 font-bold' : ''}
+          ${isLocked ? 'text-gray-500' : ''}
+        `}
+      >
+        {level.name}
+      </span>
+    </div>
+  )
+}
+
+LevelNode.propTypes = {
+  level: PropTypes.shape({
+    id: PropTypes.number.isRequired,
+    name: PropTypes.string.isRequired,
+  }).isRequired,
+  status: PropTypes.oneOf(['completed', 'current', 'locked']).isRequired,
+  nodeRef: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.shape({ current: PropTypes.any }),
+  ]),
+}
+
+/**
+ * Connector line between two level nodes.
+ */
+function Connector({ index, leftStatus, rightStatus }) {
+  const isBothCompleted = leftStatus === 'completed' && (rightStatus === 'completed' || rightStatus === 'current')
+  return (
+    <div
+      data-testid={`connector-${index}`}
+      className={`
+        shrink-0 h-0.5 w-4 md:w-6 self-center mt-[-1.25rem]
+        ${isBothCompleted ? 'bg-green-500' : 'bg-gray-600'}
+      `}
+      aria-hidden="true"
+    />
+  )
+}
+
+Connector.propTypes = {
+  index: PropTypes.number.isRequired,
+  leftStatus: PropTypes.string.isRequired,
+  rightStatus: PropTypes.string.isRequired,
+}
+
+// ── Main Component ──────────────────────────────────────────────────────────
+
+function LevelMap({ currentLevel = 1 }) {
+  const currentNodeRef = useRef(null)
+
+  // Auto-scroll to the current level on mount
+  useEffect(() => {
+    if (currentNodeRef.current) {
+      currentNodeRef.current.scrollIntoView({
+        behavior: 'smooth',
+        block: 'nearest',
+        inline: 'center',
+      })
+    }
+  }, [currentLevel])
+
+  return (
+    <div data-testid="level-map" className="w-full px-2">
+      <div
+        role="list"
+        aria-label="Level progress map"
+        className="flex items-start overflow-x-auto snap-x snap-mandatory
+                   gap-1 pb-2 scrollbar-hide"
+      >
+        {LEVELS.map((level, idx) => {
+          const status = getLevelStatus(level.id, currentLevel)
+          const isCurrent = status === 'current'
+          const nextStatus = idx < LEVELS.length - 1
+            ? getLevelStatus(LEVELS[idx + 1].id, currentLevel)
+            : null
+
+          return (
+            <div key={level.id} className="flex items-start">
+              <LevelNode
+                level={level}
+                status={status}
+                nodeRef={isCurrent ? currentNodeRef : undefined}
+              />
+              {idx < LEVELS.length - 1 && (
+                <Connector
+                  index={idx}
+                  leftStatus={status}
+                  rightStatus={nextStatus}
+                />
+              )}
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+LevelMap.propTypes = {
+  currentLevel: PropTypes.number,
+}
+
+export default LevelMap

--- a/src/components/LevelMap.test.jsx
+++ b/src/components/LevelMap.test.jsx
@@ -1,0 +1,223 @@
+/**
+ * @vitest-environment happy-dom
+ */
+import { describe, it, expect, afterEach, vi, beforeEach } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+import LevelMap from './LevelMap'
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function renderLevelMap(overrides = {}) {
+  const defaults = { currentLevel: 1 }
+  return render(<LevelMap {...defaults} {...overrides} />)
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe('LevelMap', () => {
+  beforeEach(() => {
+    // Mock scrollIntoView since happy-dom does not implement it
+    Element.prototype.scrollIntoView = vi.fn()
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.restoreAllMocks()
+  })
+
+  // ── Renders all 13 level nodes ──────────────────────────────────────
+
+  it('renders 13 level nodes', () => {
+    renderLevelMap({ currentLevel: 1 })
+    const items = screen.getAllByRole('listitem')
+    expect(items).toHaveLength(13)
+  })
+
+  // ── Level names displayed ───────────────────────────────────────────
+
+  it('displays level names below each node', () => {
+    renderLevelMap({ currentLevel: 1 })
+    expect(screen.getByText('First Steps')).toBeTruthy()
+    expect(screen.getByText('Addition Hero')).toBeTruthy()
+    expect(screen.getByText('Math Champion')).toBeTruthy()
+  })
+
+  // ── Completed levels (< currentLevel) ───────────────────────────────
+
+  describe('completed levels (< currentLevel)', () => {
+    it('shows green star for completed levels', () => {
+      renderLevelMap({ currentLevel: 4 })
+      // Levels 1, 2, 3 are completed
+      const node1 = screen.getByTestId('level-node-1')
+      const node2 = screen.getByTestId('level-node-2')
+      const node3 = screen.getByTestId('level-node-3')
+      expect(node1.querySelector('[data-testid="star-icon"]')).toBeTruthy()
+      expect(node2.querySelector('[data-testid="star-icon"]')).toBeTruthy()
+      expect(node3.querySelector('[data-testid="star-icon"]')).toBeTruthy()
+    })
+
+    it('completed levels have green text styling', () => {
+      renderLevelMap({ currentLevel: 3 })
+      const node1 = screen.getByTestId('level-node-1')
+      expect(node1.querySelector('.text-green-500')).toBeTruthy()
+    })
+  })
+
+  // ── Current level (=== currentLevel) ────────────────────────────────
+
+  describe('current level (=== currentLevel)', () => {
+    it('shows gold styling for the current level', () => {
+      renderLevelMap({ currentLevel: 5 })
+      const currentNode = screen.getByTestId('level-node-5')
+      expect(currentNode.querySelector('.text-yellow-500')).toBeTruthy()
+    })
+
+    it('current level has pulse animation class', () => {
+      renderLevelMap({ currentLevel: 5 })
+      const currentNode = screen.getByTestId('level-node-5')
+      expect(currentNode.querySelector('.animate-pulse-gold')).toBeTruthy()
+    })
+
+    it('pulse animation respects prefers-reduced-motion', () => {
+      renderLevelMap({ currentLevel: 5 })
+      const currentNode = screen.getByTestId('level-node-5')
+      const pulsingEl = currentNode.querySelector('.animate-pulse-gold')
+      expect(pulsingEl.className).toContain('motion-reduce:animate-none')
+    })
+  })
+
+  // ── Locked levels (> currentLevel) ──────────────────────────────────
+
+  describe('locked levels (> currentLevel)', () => {
+    it('shows grey/faded styling for locked levels', () => {
+      renderLevelMap({ currentLevel: 1 })
+      const lockedNode = screen.getByTestId('level-node-2')
+      expect(lockedNode.querySelector('.text-gray-400')).toBeTruthy()
+    })
+
+    it('locked levels have reduced opacity', () => {
+      renderLevelMap({ currentLevel: 1 })
+      const lockedNode = screen.getByTestId('level-node-2')
+      expect(lockedNode.querySelector('.opacity-50')).toBeTruthy()
+    })
+
+    it('locked levels show lock icon', () => {
+      renderLevelMap({ currentLevel: 1 })
+      const lockedNode = screen.getByTestId('level-node-2')
+      expect(lockedNode.querySelector('[data-testid="lock-icon"]')).toBeTruthy()
+    })
+  })
+
+  // ── Accessibility ───────────────────────────────────────────────────
+
+  describe('accessibility', () => {
+    it('container has role="list"', () => {
+      renderLevelMap({ currentLevel: 1 })
+      const list = screen.getByRole('list')
+      expect(list).toBeTruthy()
+    })
+
+    it('each node has role="listitem"', () => {
+      renderLevelMap({ currentLevel: 1 })
+      const items = screen.getAllByRole('listitem')
+      expect(items).toHaveLength(13)
+    })
+
+    it('completed level has correct aria-label', () => {
+      renderLevelMap({ currentLevel: 3 })
+      const node1 = screen.getByTestId('level-node-1')
+      expect(node1.getAttribute('aria-label')).toBe('Level 1: First Steps - completed')
+    })
+
+    it('current level has correct aria-label', () => {
+      renderLevelMap({ currentLevel: 3 })
+      const node3 = screen.getByTestId('level-node-3')
+      expect(node3.getAttribute('aria-label')).toBe('Level 3: Minus Magic - current')
+    })
+
+    it('locked level has correct aria-label', () => {
+      renderLevelMap({ currentLevel: 3 })
+      const node4 = screen.getByTestId('level-node-4')
+      expect(node4.getAttribute('aria-label')).toBe('Level 4: Mixed Warrior - locked')
+    })
+  })
+
+  // ── Auto-scroll ─────────────────────────────────────────────────────
+
+  describe('auto-scroll', () => {
+    it('scrolls the current level node into view on mount', () => {
+      renderLevelMap({ currentLevel: 7 })
+      const currentNode = screen.getByTestId('level-node-7')
+      expect(currentNode.scrollIntoView).toHaveBeenCalledWith(
+        expect.objectContaining({ inline: 'center' })
+      )
+    })
+  })
+
+  // ── Boundary conditions ─────────────────────────────────────────────
+
+  describe('boundary conditions', () => {
+    it('currentLevel=1 — no completed levels, first is current, rest locked', () => {
+      renderLevelMap({ currentLevel: 1 })
+      // Level 1 is current (gold)
+      const node1 = screen.getByTestId('level-node-1')
+      expect(node1.getAttribute('aria-label')).toBe('Level 1: First Steps - current')
+      // Level 2 is locked
+      const node2 = screen.getByTestId('level-node-2')
+      expect(node2.getAttribute('aria-label')).toBe('Level 2: Addition Hero - locked')
+    })
+
+    it('currentLevel=13 — 12 completed, last is current, none locked', () => {
+      renderLevelMap({ currentLevel: 13 })
+      // Level 12 is completed
+      const node12 = screen.getByTestId('level-node-12')
+      expect(node12.getAttribute('aria-label')).toBe('Level 12: Division Quest - completed')
+      // Level 13 is current
+      const node13 = screen.getByTestId('level-node-13')
+      expect(node13.getAttribute('aria-label')).toBe('Level 13: Math Champion - current')
+      // No locked levels - all 13 are either completed or current
+      const items = screen.getAllByRole('listitem')
+      const lockedItems = items.filter(
+        item => item.getAttribute('aria-label')?.includes('locked')
+      )
+      expect(lockedItems).toHaveLength(0)
+    })
+  })
+
+  // ── Responsive container ────────────────────────────────────────────
+
+  describe('responsive container', () => {
+    it('has horizontal scroll container class', () => {
+      renderLevelMap({ currentLevel: 1 })
+      const list = screen.getByRole('list')
+      expect(list.className).toContain('overflow-x-auto')
+    })
+
+    it('has snap scrolling class', () => {
+      renderLevelMap({ currentLevel: 1 })
+      const list = screen.getByRole('list')
+      expect(list.className).toContain('snap-x')
+    })
+  })
+
+  // ── Connecting lines ────────────────────────────────────────────────
+
+  describe('connecting lines', () => {
+    it('renders connecting lines between nodes', () => {
+      renderLevelMap({ currentLevel: 1 })
+      const lines = screen.getByTestId('level-map').querySelectorAll('[data-testid^="connector-"]')
+      // 12 connectors between 13 nodes
+      expect(lines).toHaveLength(12)
+    })
+  })
+
+  // ── Default prop ────────────────────────────────────────────────────
+
+  describe('default prop behavior', () => {
+    it('renders without currentLevel prop (defaults handled gracefully)', () => {
+      render(<LevelMap />)
+      const items = screen.getAllByRole('listitem')
+      expect(items).toHaveLength(13)
+    })
+  })
+})

--- a/src/components/LevelUpScreen.jsx
+++ b/src/components/LevelUpScreen.jsx
@@ -5,6 +5,10 @@
  * 'start', 'game', 'result'). Displays celebration animation,
  * completed level info, and a CTA to continue to the next level.
  *
+ * When the player completes the final level (MAX_LEVEL), a special
+ * "Champion" variant is shown with a trophy emoji, a distinct title,
+ * and a "Play Again at Level 13!" button that does NOT increment.
+ *
  * Visual MVP: emoji hero + CSS confetti particles, no audio.
  *
  * @param {Object}   props
@@ -13,7 +17,7 @@
  */
 
 import PropTypes from 'prop-types'
-import { LEVELS } from '../config/levels'
+import { LEVELS, MAX_LEVEL } from '../config/levels'
 
 /** Number of confetti particles to render */
 const CONFETTI_COUNT = 12
@@ -30,8 +34,8 @@ const CONFETTI_COLORS = [
 
 function LevelUpScreen({ completedLevel, onContinue }) {
   const completedLevelConfig = LEVELS[completedLevel - 1]
-  const isMaxLevel = completedLevel >= LEVELS.length
-  const nextLevelConfig = isMaxLevel ? null : LEVELS[completedLevel]
+  const isChampion = completedLevel >= MAX_LEVEL
+  const nextLevelConfig = isChampion ? null : LEVELS[completedLevel]
 
   return (
     <div className="min-h-screen bg-gradient-to-b from-sonic-blue to-blue-900 flex flex-col items-center justify-center p-4 relative overflow-hidden">
@@ -55,32 +59,35 @@ function LevelUpScreen({ completedLevel, onContinue }) {
         />
       ))}
 
-      {/* Hero emoji with bounce animation */}
+      {/* Hero emoji with bounce animation — trophy for champion, rocket otherwise */}
       <div
         data-testid="hero-emoji"
         className="text-7xl md:text-8xl mb-4 animate-bounce-hero motion-reduce:animate-none"
         aria-hidden="true"
       >
-        🚀
+        {isChampion ? '\uD83C\uDFC6' : '\uD83D\uDE80'}
       </div>
 
       {/* Screen-reader announcement */}
       <div role="status" aria-live="polite" className="sr-only">
-        Level complete! You finished {completedLevelConfig?.name}.
-        {nextLevelConfig ? ` Next up: ${nextLevelConfig.name}.` : ' You have completed all levels!'}
+        {isChampion
+          ? `Congratulations! You mastered all ${MAX_LEVEL} levels!`
+          : `Level complete! You finished ${completedLevelConfig?.name}. Next up: ${nextLevelConfig?.name}.`}
       </div>
 
       {/* Main heading */}
       <h1 className="text-4xl md:text-6xl font-game text-sonic-gold drop-shadow-lg text-center mb-2">
-        Level Complete!
+        {isChampion ? 'Math Champion!' : 'Level Complete!'}
       </h1>
 
-      {/* Completed level name */}
+      {/* Sub-message */}
       <p className="text-xl md:text-2xl font-game text-white text-center mb-1">
-        {completedLevelConfig?.name}
+        {isChampion
+          ? `You mastered all ${MAX_LEVEL} levels!`
+          : completedLevelConfig?.name}
       </p>
 
-      {/* Next level subheading */}
+      {/* Next level subheading (normal flow only) */}
       {nextLevelConfig && (
         <p className="text-lg md:text-xl font-game text-yellow-200 text-center mb-8">
           Next: {nextLevelConfig.name}
@@ -102,13 +109,13 @@ function LevelUpScreen({ completedLevel, onContinue }) {
           focus:outline-none focus:ring-2 focus:ring-yellow-300
         "
         aria-label={
-          isMaxLevel
-            ? 'Continue playing'
+          isChampion
+            ? `Play Again at Level ${MAX_LEVEL}`
             : `Continue to Level ${completedLevel + 1}`
         }
       >
-        {isMaxLevel
-          ? 'Keep Playing!'
+        {isChampion
+          ? `Play Again at Level ${MAX_LEVEL}!`
           : `Continue to Level ${completedLevel + 1}!`}
       </button>
 

--- a/src/components/LevelUpScreen.jsx
+++ b/src/components/LevelUpScreen.jsx
@@ -1,0 +1,126 @@
+/**
+ * LevelUpScreen -- Celebration screen when player completes a level
+ *
+ * Shown as a full-screen state in App.jsx's state machine (peer to
+ * 'start', 'game', 'result'). Displays celebration animation,
+ * completed level info, and a CTA to continue to the next level.
+ *
+ * Visual MVP: emoji hero + CSS confetti particles, no audio.
+ *
+ * @param {Object}   props
+ * @param {number}   props.completedLevel  The level just completed (1-13)
+ * @param {Function} props.onContinue      Callback when user clicks Continue
+ */
+
+import PropTypes from 'prop-types'
+import { LEVELS } from '../config/levels'
+
+/** Number of confetti particles to render */
+const CONFETTI_COUNT = 12
+
+/** Confetti color palette */
+const CONFETTI_COLORS = [
+  'bg-yellow-400',
+  'bg-pink-400',
+  'bg-blue-400',
+  'bg-green-400',
+  'bg-purple-400',
+  'bg-red-400',
+]
+
+function LevelUpScreen({ completedLevel, onContinue }) {
+  const completedLevelConfig = LEVELS[completedLevel - 1]
+  const isMaxLevel = completedLevel >= LEVELS.length
+  const nextLevelConfig = isMaxLevel ? null : LEVELS[completedLevel]
+
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-sonic-blue to-blue-900 flex flex-col items-center justify-center p-4 relative overflow-hidden">
+      {/* Confetti particles (pure CSS animation) */}
+      {Array.from({ length: CONFETTI_COUNT }).map((_, i) => (
+        <span
+          key={i}
+          data-testid="confetti-particle"
+          className={`
+            absolute w-3 h-3 rounded-full
+            ${CONFETTI_COLORS[i % CONFETTI_COLORS.length]}
+            animate-confetti-fall motion-reduce:hidden
+            opacity-80
+          `}
+          style={{
+            left: `${8 + (i * 84) / CONFETTI_COUNT}%`,
+            animationDelay: `${i * 0.15}s`,
+            animationDuration: `${1.5 + (i % 3) * 0.5}s`,
+          }}
+          aria-hidden="true"
+        />
+      ))}
+
+      {/* Hero emoji with bounce animation */}
+      <div
+        data-testid="hero-emoji"
+        className="text-7xl md:text-8xl mb-4 animate-bounce-hero motion-reduce:animate-none"
+        aria-hidden="true"
+      >
+        🚀
+      </div>
+
+      {/* Screen-reader announcement */}
+      <div role="status" aria-live="polite" className="sr-only">
+        Level complete! You finished {completedLevelConfig?.name}.
+        {nextLevelConfig ? ` Next up: ${nextLevelConfig.name}.` : ' You have completed all levels!'}
+      </div>
+
+      {/* Main heading */}
+      <h1 className="text-4xl md:text-6xl font-game text-sonic-gold drop-shadow-lg text-center mb-2">
+        Level Complete!
+      </h1>
+
+      {/* Completed level name */}
+      <p className="text-xl md:text-2xl font-game text-white text-center mb-1">
+        {completedLevelConfig?.name}
+      </p>
+
+      {/* Next level subheading */}
+      {nextLevelConfig && (
+        <p className="text-lg md:text-xl font-game text-yellow-200 text-center mb-8">
+          Next: {nextLevelConfig.name}
+        </p>
+      )}
+
+      {/* Spacer when no next level */}
+      {!nextLevelConfig && <div className="mb-8" />}
+
+      {/* Continue CTA button */}
+      <button
+        onClick={onContinue}
+        className="
+          min-h-[44px] px-8 py-4
+          bg-sonic-gold text-sonic-blue font-game text-xl md:text-2xl
+          rounded-full shadow-lg
+          transform transition-all duration-200
+          hover:bg-yellow-400 hover:scale-105 active:scale-95
+          focus:outline-none focus:ring-2 focus:ring-yellow-300
+        "
+        aria-label={
+          isMaxLevel
+            ? 'Continue playing'
+            : `Continue to Level ${completedLevel + 1}`
+        }
+      >
+        {isMaxLevel
+          ? 'Keep Playing!'
+          : `Continue to Level ${completedLevel + 1}!`}
+      </button>
+
+      {/* Audio placeholder for future audio hook */}
+      <span data-testid="audio-placeholder" aria-hidden="true" />
+    </div>
+  )
+}
+
+LevelUpScreen.propTypes = {
+  completedLevel: PropTypes.number.isRequired,
+  onContinue: PropTypes.func.isRequired,
+}
+
+export default LevelUpScreen

--- a/src/components/LevelUpScreen.test.jsx
+++ b/src/components/LevelUpScreen.test.jsx
@@ -1,0 +1,182 @@
+/**
+ * @vitest-environment happy-dom
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+
+// Mock levels config
+vi.mock('../config/levels', () => ({
+  LEVELS: [
+    { id: 1, name: 'First Steps' },
+    { id: 2, name: 'Addition Hero' },
+    { id: 3, name: 'Minus Magic' },
+    { id: 4, name: 'Mixed Warrior' },
+    { id: 5, name: 'Cross the 10' },
+    { id: 6, name: 'Subtract 20' },
+    { id: 7, name: 'Mixed 20' },
+    { id: 8, name: 'Tens Master' },
+    { id: 9, name: 'Century Runner' },
+    { id: 10, name: 'Speed of 2s' },
+    { id: 11, name: 'Times Tables' },
+    { id: 12, name: 'Division Quest' },
+    { id: 13, name: 'Math Champion' },
+  ],
+}))
+
+// Import after mocks
+const { default: LevelUpScreen } = await import('./LevelUpScreen')
+
+describe('LevelUpScreen', () => {
+  const mockOnContinue = vi.fn()
+
+  beforeEach(() => {
+    cleanup()
+    vi.clearAllMocks()
+  })
+
+  // ── Rendering ──────────────────────────────────────────────────────
+
+  describe('rendering', () => {
+    it('renders the "Level Complete!" heading', () => {
+      render(<LevelUpScreen completedLevel={1} onContinue={mockOnContinue} />)
+      expect(screen.getByRole('heading', { level: 1 })).toBeTruthy()
+      expect(screen.getByText('Level Complete!')).toBeTruthy()
+    })
+
+    it('displays the completed level name', () => {
+      render(<LevelUpScreen completedLevel={3} onContinue={mockOnContinue} />)
+      expect(screen.getAllByText(/Minus Magic/).length).toBeGreaterThanOrEqual(1)
+    })
+
+    it('displays the next level name for mid-range levels', () => {
+      render(<LevelUpScreen completedLevel={5} onContinue={mockOnContinue} />)
+      expect(screen.getAllByText(/Subtract 20/).length).toBeGreaterThanOrEqual(1)
+    })
+
+    it('renders hero emoji with bounce animation', () => {
+      render(<LevelUpScreen completedLevel={1} onContinue={mockOnContinue} />)
+      const hero = screen.getByTestId('hero-emoji')
+      expect(hero).toBeTruthy()
+      expect(hero.className).toContain('animate-bounce-hero')
+    })
+
+    it('renders confetti particles', () => {
+      render(<LevelUpScreen completedLevel={1} onContinue={mockOnContinue} />)
+      const particles = screen.getAllByTestId('confetti-particle')
+      expect(particles.length).toBeGreaterThanOrEqual(8)
+    })
+
+    it('renders audio placeholder for future audio hook', () => {
+      render(<LevelUpScreen completedLevel={1} onContinue={mockOnContinue} />)
+      expect(screen.getByTestId('audio-placeholder')).toBeTruthy()
+    })
+  })
+
+  // ── Continue button ────────────────────────────────────────────────
+
+  describe('continue button', () => {
+    it('renders the continue button with next level number', () => {
+      render(<LevelUpScreen completedLevel={4} onContinue={mockOnContinue} />)
+      expect(screen.getByRole('button', { name: /Continue to Level 5/i })).toBeTruthy()
+    })
+
+    it('calls onContinue when continue button is clicked', () => {
+      render(<LevelUpScreen completedLevel={2} onContinue={mockOnContinue} />)
+      fireEvent.click(screen.getByRole('button', { name: /Continue to Level 3/i }))
+      expect(mockOnContinue).toHaveBeenCalledTimes(1)
+    })
+
+    it('has min touch target of 44px', () => {
+      render(<LevelUpScreen completedLevel={1} onContinue={mockOnContinue} />)
+      const button = screen.getByRole('button', { name: /Continue/i })
+      expect(button.className).toContain('min-h-[44px]')
+    })
+  })
+
+  // ── Max level guard ────────────────────────────────────────────────
+
+  describe('max level (level 13)', () => {
+    it('does not show "Next" level name when completed level is 13', () => {
+      render(<LevelUpScreen completedLevel={13} onContinue={mockOnContinue} />)
+      expect(screen.queryByText(/Next:/)).toBeNull()
+    })
+
+    it('shows completed level 13 name (Math Champion)', () => {
+      render(<LevelUpScreen completedLevel={13} onContinue={mockOnContinue} />)
+      expect(screen.getAllByText(/Math Champion/).length).toBeGreaterThanOrEqual(1)
+    })
+
+    it('shows a different CTA for max level (no level number)', () => {
+      render(<LevelUpScreen completedLevel={13} onContinue={mockOnContinue} />)
+      const button = screen.getByRole('button')
+      expect(button.textContent).not.toContain('Level 14')
+    })
+
+    it('CTA button still calls onContinue for max level', () => {
+      render(<LevelUpScreen completedLevel={13} onContinue={mockOnContinue} />)
+      fireEvent.click(screen.getByRole('button'))
+      expect(mockOnContinue).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  // ── Various completed levels ───────────────────────────────────────
+
+  describe('various completed levels', () => {
+    it('renders correctly for level 1', () => {
+      render(<LevelUpScreen completedLevel={1} onContinue={mockOnContinue} />)
+      expect(screen.getAllByText(/First Steps/).length).toBeGreaterThanOrEqual(1)
+      expect(screen.getAllByText(/Addition Hero/).length).toBeGreaterThanOrEqual(1)
+    })
+
+    it('renders correctly for level 7', () => {
+      render(<LevelUpScreen completedLevel={7} onContinue={mockOnContinue} />)
+      expect(screen.getAllByText(/Mixed 20/).length).toBeGreaterThanOrEqual(1)
+      expect(screen.getAllByText(/Tens Master/).length).toBeGreaterThanOrEqual(1)
+    })
+
+    it('renders correctly for level 12', () => {
+      render(<LevelUpScreen completedLevel={12} onContinue={mockOnContinue} />)
+      expect(screen.getAllByText(/Division Quest/).length).toBeGreaterThanOrEqual(1)
+      expect(screen.getAllByText(/Math Champion/).length).toBeGreaterThanOrEqual(1)
+    })
+  })
+
+  // ── Accessibility ──────────────────────────────────────────────────
+
+  describe('accessibility', () => {
+    it('has aria-live="polite" on announcement region', () => {
+      render(<LevelUpScreen completedLevel={1} onContinue={mockOnContinue} />)
+      const region = screen.getByRole('status')
+      expect(region.getAttribute('aria-live')).toBe('polite')
+    })
+
+    it('has role="status" on announcement region', () => {
+      render(<LevelUpScreen completedLevel={1} onContinue={mockOnContinue} />)
+      expect(screen.getByRole('status')).toBeTruthy()
+    })
+
+    it('uses proper heading hierarchy (h1 for main heading)', () => {
+      render(<LevelUpScreen completedLevel={1} onContinue={mockOnContinue} />)
+      const heading = screen.getByRole('heading', { level: 1 })
+      expect(heading.textContent).toBe('Level Complete!')
+    })
+  })
+
+  // ── Reduced motion ─────────────────────────────────────────────────
+
+  describe('reduced motion', () => {
+    it('hero emoji has motion-reduce class to disable animation', () => {
+      render(<LevelUpScreen completedLevel={1} onContinue={mockOnContinue} />)
+      const hero = screen.getByTestId('hero-emoji')
+      expect(hero.className).toContain('motion-reduce:animate-none')
+    })
+
+    it('confetti particles have motion-reduce class', () => {
+      render(<LevelUpScreen completedLevel={1} onContinue={mockOnContinue} />)
+      const particles = screen.getAllByTestId('confetti-particle')
+      particles.forEach((particle) => {
+        expect(particle.className).toContain('motion-reduce:hidden')
+      })
+    })
+  })
+})

--- a/src/components/LevelUpScreen.test.jsx
+++ b/src/components/LevelUpScreen.test.jsx
@@ -21,6 +21,7 @@ vi.mock('../config/levels', () => ({
     { id: 12, name: 'Division Quest' },
     { id: 13, name: 'Math Champion' },
   ],
+  MAX_LEVEL: 13,
 }))
 
 // Import after mocks
@@ -101,12 +102,7 @@ describe('LevelUpScreen', () => {
       expect(screen.queryByText(/Next:/)).toBeNull()
     })
 
-    it('shows completed level 13 name (Math Champion)', () => {
-      render(<LevelUpScreen completedLevel={13} onContinue={mockOnContinue} />)
-      expect(screen.getAllByText(/Math Champion/).length).toBeGreaterThanOrEqual(1)
-    })
-
-    it('shows a different CTA for max level (no level number)', () => {
+    it('shows a different CTA for max level (no level number 14)', () => {
       render(<LevelUpScreen completedLevel={13} onContinue={mockOnContinue} />)
       const button = screen.getByRole('button')
       expect(button.textContent).not.toContain('Level 14')
@@ -116,6 +112,92 @@ describe('LevelUpScreen', () => {
       render(<LevelUpScreen completedLevel={13} onContinue={mockOnContinue} />)
       fireEvent.click(screen.getByRole('button'))
       expect(mockOnContinue).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  // ── Champion variant (level 13 completion) ───────────────────────
+
+  describe('champion variant', () => {
+    it('shows "Math Champion!" heading instead of "Level Complete!"', () => {
+      render(<LevelUpScreen completedLevel={13} onContinue={mockOnContinue} />)
+      expect(screen.getByRole('heading', { level: 1 }).textContent).toBe('Math Champion!')
+      expect(screen.queryByText('Level Complete!')).toBeNull()
+    })
+
+    it('shows trophy emoji instead of rocket', () => {
+      render(<LevelUpScreen completedLevel={13} onContinue={mockOnContinue} />)
+      const hero = screen.getByTestId('hero-emoji')
+      expect(hero.textContent).toBe('\uD83C\uDFC6')
+      expect(hero.textContent).not.toBe('\uD83D\uDE80')
+    })
+
+    it('shows "You mastered all 13 levels!" message', () => {
+      render(<LevelUpScreen completedLevel={13} onContinue={mockOnContinue} />)
+      expect(screen.getByText('You mastered all 13 levels!')).toBeTruthy()
+    })
+
+    it('shows "Play Again at Level 13!" button', () => {
+      render(<LevelUpScreen completedLevel={13} onContinue={mockOnContinue} />)
+      const button = screen.getByRole('button')
+      expect(button.textContent).toBe('Play Again at Level 13!')
+    })
+
+    it('button has correct aria-label for champion', () => {
+      render(<LevelUpScreen completedLevel={13} onContinue={mockOnContinue} />)
+      const button = screen.getByRole('button')
+      expect(button.getAttribute('aria-label')).toBe('Play Again at Level 13')
+    })
+
+    it('screen-reader announcement mentions mastering all levels', () => {
+      render(<LevelUpScreen completedLevel={13} onContinue={mockOnContinue} />)
+      const status = screen.getByRole('status')
+      expect(status.textContent).toContain('mastered all 13 levels')
+    })
+
+    it('confetti still renders in champion mode', () => {
+      render(<LevelUpScreen completedLevel={13} onContinue={mockOnContinue} />)
+      const particles = screen.getAllByTestId('confetti-particle')
+      expect(particles.length).toBeGreaterThanOrEqual(8)
+    })
+
+    it('hero emoji still has bounce animation in champion mode', () => {
+      render(<LevelUpScreen completedLevel={13} onContinue={mockOnContinue} />)
+      const hero = screen.getByTestId('hero-emoji')
+      expect(hero.className).toContain('animate-bounce-hero')
+    })
+
+    it('does not show the completed level config name as sub-message', () => {
+      render(<LevelUpScreen completedLevel={13} onContinue={mockOnContinue} />)
+      // The sub-message should be "You mastered all 13 levels!" not the level name
+      // The level name "Math Champion" could appear in heading — but NOT as level config display
+      const paragraphs = screen.getAllByText(/mastered all 13/)
+      expect(paragraphs.length).toBeGreaterThanOrEqual(1)
+    })
+  })
+
+  // ── Boundary: level 12 to 13 (normal level-up) ───────────────────
+
+  describe('boundary: level 12 (normal level-up to 13)', () => {
+    it('shows "Level Complete!" heading for level 12', () => {
+      render(<LevelUpScreen completedLevel={12} onContinue={mockOnContinue} />)
+      expect(screen.getByRole('heading', { level: 1 }).textContent).toBe('Level Complete!')
+    })
+
+    it('shows rocket emoji for level 12', () => {
+      render(<LevelUpScreen completedLevel={12} onContinue={mockOnContinue} />)
+      const hero = screen.getByTestId('hero-emoji')
+      expect(hero.textContent).toBe('\uD83D\uDE80')
+    })
+
+    it('shows "Continue to Level 13!" button for level 12', () => {
+      render(<LevelUpScreen completedLevel={12} onContinue={mockOnContinue} />)
+      const button = screen.getByRole('button', { name: /Continue to Level 13/i })
+      expect(button.textContent).toBe('Continue to Level 13!')
+    })
+
+    it('shows Next: Math Champion for level 12', () => {
+      render(<LevelUpScreen completedLevel={12} onContinue={mockOnContinue} />)
+      expect(screen.getByText(/Next: Math Champion/)).toBeTruthy()
     })
   })
 

--- a/src/components/ResultScreen.jsx
+++ b/src/components/ResultScreen.jsx
@@ -1,4 +1,5 @@
 import PropTypes from 'prop-types'
+import { getTheme } from '../config/themes'
 
 /**
  * ResultScreen Component - End-of-game summary screen
@@ -21,7 +22,8 @@ import PropTypes from 'prop-types'
  * @param {function} onPlayAgain - Callback when user wants to play again
  * @param {function} onExit - Callback when user wants to go back to start
  */
-function ResultScreen({ sessionStats, onPlayAgain, onExit }) {
+function ResultScreen({ sessionStats, onPlayAgain, onExit, theme: themeKey = null }) {
+  const themeObj = getTheme(themeKey)
   // Destructure stats with defaults
   const {
     score = 0,
@@ -35,8 +37,8 @@ function ResultScreen({ sessionStats, onPlayAgain, onExit }) {
   const getPerformanceMessage = () => {
     if (accuracy >= 80) {
       return {
-        text: 'Sonic Speed! Amazing!',
-        emoji: '\u{1F994}\u{1F4A8}', // hedgehog + dash
+        text: themeObj.amazingMessage,
+        emoji: themeObj.emoji,
         color: 'text-green-400',
       }
     }
@@ -208,6 +210,7 @@ ResultScreen.propTypes = {
   }).isRequired,
   onPlayAgain: PropTypes.func.isRequired,
   onExit: PropTypes.func.isRequired,
+  theme: PropTypes.string,
 }
 
 export default ResultScreen

--- a/src/components/ScoreDisplay.jsx
+++ b/src/components/ScoreDisplay.jsx
@@ -1,4 +1,5 @@
 import PropTypes from 'prop-types'
+import { getTheme } from '../config/themes'
 
 /**
  * ScoreDisplay Component - Shows score and streak in Sonic theme
@@ -9,12 +10,14 @@ import PropTypes from 'prop-types'
  * @param {number} score - Current game score
  * @param {number} streak - Current correct answer streak
  */
-function ScoreDisplay({ score, streak }) {
+function ScoreDisplay({ score, streak, theme: themeKey = null }) {
+  const themeObj = getTheme(themeKey)
+
   // Determine streak emoji based on streak count
   const getStreakEmoji = () => {
     if (streak >= 10) return { emoji: '\u{1F525}', label: 'On Fire!' }  // Fire
     if (streak >= 5) return { emoji: '\u{26A1}', label: 'Lightning!' }  // Lightning
-    if (streak >= 3) return { emoji: '\u{1F994}', label: 'Speedy!' }    // Hedgehog
+    if (streak >= 3) return { emoji: themeObj.streakEmoji, label: 'Speedy!' }
     return { emoji: '\u{2B50}', label: 'Keep going!' }                  // Star
   }
 
@@ -76,6 +79,7 @@ function ScoreDisplay({ score, streak }) {
 ScoreDisplay.propTypes = {
   score: PropTypes.number.isRequired,
   streak: PropTypes.number.isRequired,
+  theme: PropTypes.string,
 }
 
 export default ScoreDisplay

--- a/src/components/StartScreen.jsx
+++ b/src/components/StartScreen.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types'
 import LevelMap from './LevelMap'
+import { getTheme } from '../config/themes'
 
 /**
  * StartScreen Component - Welcome screen before game starts
@@ -22,7 +23,9 @@ import LevelMap from './LevelMap'
  * @param {number} progress.correctAnswers - Total correct answers
  * @param {number} [currentLevel=1] - The player's current level (1-13)
  */
-function StartScreen({ onStart, progress = null, currentLevel = 1 }) {
+function StartScreen({ onStart, progress = null, currentLevel = 1, activeProfile = null }) {
+  const theme = getTheme(activeProfile?.theme)
+
   // Check if user has previous progress to display
   const hasPreviousProgress = progress && (progress.score > 0 || progress.streak > 0)
 
@@ -47,13 +50,12 @@ function StartScreen({ onStart, progress = null, currentLevel = 1 }) {
           className="text-4xl md:text-5xl lg:text-6xl font-game text-white
                      drop-shadow-lg mb-4 animate-pulse-scale"
         >
-          Sonic Math Trainer!
+          {theme.titlePrefix} Math Trainer!
         </h1>
 
-        {/* Sonic Emoji Row */}
+        {/* Hero Emoji Row */}
         <div className="flex justify-center gap-2 text-4xl md:text-5xl mb-6">
-          <span role="img" aria-label="hedgehog">&#x1F994;</span>
-          <span role="img" aria-label="dash">&#x1F4A8;</span>
+          <span role="img" aria-label={theme.name}>{theme.emoji}</span>
         </div>
 
         {/* Subtitle */}
@@ -157,6 +159,9 @@ StartScreen.propTypes = {
     correctAnswers: PropTypes.number,
   }),
   currentLevel: PropTypes.number,
+  activeProfile: PropTypes.shape({
+    theme: PropTypes.string,
+  }),
 }
 
 export default StartScreen

--- a/src/components/StartScreen.jsx
+++ b/src/components/StartScreen.jsx
@@ -1,4 +1,5 @@
 import PropTypes from 'prop-types'
+import LevelMap from './LevelMap'
 
 /**
  * StartScreen Component - Welcome screen before game starts
@@ -9,6 +10,7 @@ import PropTypes from 'prop-types'
  * Features:
  * - Welcome message with Sonic theme
  * - Subtitle explaining game purpose
+ * - Level progress map showing all 13 levels
  * - Large, prominent "Start Game" button
  * - Previous best score/streak display (if available)
  *
@@ -18,8 +20,9 @@ import PropTypes from 'prop-types'
  * @param {number} progress.streak - Best streak achieved
  * @param {number} progress.totalProblems - Total problems attempted
  * @param {number} progress.correctAnswers - Total correct answers
+ * @param {number} [currentLevel=1] - The player's current level (1-13)
  */
-function StartScreen({ onStart, progress = null }) {
+function StartScreen({ onStart, progress = null, currentLevel = 1 }) {
   // Check if user has previous progress to display
   const hasPreviousProgress = progress && (progress.score > 0 || progress.streak > 0)
 
@@ -106,6 +109,11 @@ function StartScreen({ onStart, progress = null }) {
           </div>
         )}
 
+        {/* Level Progress Map */}
+        <div className="mb-8">
+          <LevelMap currentLevel={currentLevel} />
+        </div>
+
         {/* Start Game Button - Large and Prominent */}
         <button
           onClick={onStart}
@@ -148,6 +156,7 @@ StartScreen.propTypes = {
     totalProblems: PropTypes.number,
     correctAnswers: PropTypes.number,
   }),
+  currentLevel: PropTypes.number,
 }
 
 export default StartScreen

--- a/src/components/StartScreen.test.jsx
+++ b/src/components/StartScreen.test.jsx
@@ -1,0 +1,55 @@
+/**
+ * @vitest-environment happy-dom
+ */
+import { describe, it, expect, afterEach, vi, beforeEach } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+import StartScreen from './StartScreen'
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function renderStartScreen(overrides = {}) {
+  const defaults = {
+    onStart: vi.fn(),
+    progress: null,
+    currentLevel: 1,
+  }
+  return render(<StartScreen {...defaults} {...overrides} />)
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe('StartScreen — LevelMap integration', () => {
+  beforeEach(() => {
+    // Mock scrollIntoView since happy-dom does not implement it
+    Element.prototype.scrollIntoView = vi.fn()
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.restoreAllMocks()
+  })
+
+  it('renders the LevelMap component', () => {
+    renderStartScreen({ currentLevel: 1 })
+    expect(screen.getByTestId('level-map')).toBeTruthy()
+  })
+
+  it('passes currentLevel to LevelMap', () => {
+    renderStartScreen({ currentLevel: 5 })
+    // Level 5 should be current
+    const node5 = screen.getByTestId('level-node-5')
+    expect(node5.getAttribute('aria-label')).toBe('Level 5: Cross the 10 - current')
+  })
+
+  it('renders 13 level nodes inside LevelMap', () => {
+    renderStartScreen({ currentLevel: 1 })
+    const items = screen.getAllByRole('listitem')
+    expect(items).toHaveLength(13)
+  })
+
+  it('defaults currentLevel to 1 when not provided', () => {
+    render(<StartScreen onStart={vi.fn()} />)
+    const node1 = screen.getByTestId('level-node-1')
+    expect(node1.getAttribute('aria-label')).toBe('Level 1: First Steps - current')
+  })
+})

--- a/src/components/__tests__/LevelProgression.integration.test.jsx
+++ b/src/components/__tests__/LevelProgression.integration.test.jsx
@@ -1,0 +1,506 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Integration tests for the complete level progression flow.
+ *
+ * These tests exercise the App component with mocked child components,
+ * verifying the full lifecycle:
+ *   Start -> Game -> LevelUp -> Continue -> Game (next level)
+ *   Start -> Game -> LevelUp (champion) -> Play Again -> Game (same level)
+ *
+ * Mocking strategy:
+ * - Firebase (useFirebase, useGameProgress): fully mocked
+ * - useProfile: mocked with controllable activeProfile
+ * - Child components: lightweight createElement stubs exposing callbacks
+ * - levels config: real LEVELS + MAX_LEVEL to test actual boundary at 13
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+import { createElement } from 'react'
+
+// ── Mocks ────────────────────────────────────────────────────────────────────
+
+// Mock levels config — use real values
+vi.mock('../../config/levels', () => ({
+  MAX_LEVEL: 13,
+  LEVELS: [
+    { id: 1, name: 'First Steps' },
+    { id: 2, name: 'Addition Hero' },
+    { id: 3, name: 'Minus Magic' },
+    { id: 4, name: 'Mixed Warrior' },
+    { id: 5, name: 'Cross the 10' },
+    { id: 6, name: 'Subtract 20' },
+    { id: 7, name: 'Mixed 20' },
+    { id: 8, name: 'Tens Master' },
+    { id: 9, name: 'Century Runner' },
+    { id: 10, name: 'Speed of 2s' },
+    { id: 11, name: 'Times Tables' },
+    { id: 12, name: 'Division Quest' },
+    { id: 13, name: 'Math Champion' },
+  ],
+  getLevelConfig: (id) => ({ id, name: `Level ${id}` }),
+  default: [
+    { id: 1, name: 'First Steps' },
+    { id: 2, name: 'Addition Hero' },
+    { id: 3, name: 'Minus Magic' },
+    { id: 4, name: 'Mixed Warrior' },
+    { id: 5, name: 'Cross the 10' },
+    { id: 6, name: 'Subtract 20' },
+    { id: 7, name: 'Mixed 20' },
+    { id: 8, name: 'Tens Master' },
+    { id: 9, name: 'Century Runner' },
+    { id: 10, name: 'Speed of 2s' },
+    { id: 11, name: 'Times Tables' },
+    { id: 12, name: 'Division Quest' },
+    { id: 13, name: 'Math Champion' },
+  ],
+}))
+
+// Mock useProfile with controllable return value
+const mockProfileCtx = {
+  activeProfile: null,
+  isLoading: false,
+  clearActiveProfile: vi.fn(),
+  createAndActivate: vi.fn(),
+  updateProfile: vi.fn(),
+}
+
+vi.mock('../../context/useProfile', () => ({
+  useProfile: () => mockProfileCtx,
+}))
+
+// Mock Firebase hooks
+const mockFirebase = {
+  user: { uid: 'test-uid' },
+  loading: false,
+  error: null,
+}
+
+const mockForceSave = vi.fn()
+
+vi.mock('../../hooks', () => ({
+  useFirebase: () => mockFirebase,
+  useGameProgress: () => ({
+    progress: { score: 0, streak: 0, totalProblems: 0, correctAnswers: 0 },
+    updateProgress: vi.fn(),
+    forceSave: mockForceSave,
+    loading: false,
+  }),
+}))
+
+// Mock child components with testable interaction surfaces.
+// Each stub exposes its props via data attributes and onClick handlers
+// so integration tests can drive the full App state machine.
+vi.mock('../../components', () => ({
+  StartScreen: ({ onStart, onSwitchProfile, currentLevel }) =>
+    createElement('div', {
+      'data-testid': 'start-screen',
+      'data-current-level': currentLevel,
+    },
+      createElement('button', { 'data-testid': 'start-game', onClick: onStart }, 'Start'),
+      createElement('button', { 'data-testid': 'switch-profile', onClick: onSwitchProfile }, 'Switch'),
+    ),
+  GameScreen: ({ onGameEnd, currentLevel, onLevelUp }) =>
+    createElement('div', {
+      'data-testid': 'game-screen',
+      'data-current-level': currentLevel,
+    },
+      createElement('button', {
+        'data-testid': 'end-game',
+        onClick: () => onGameEnd({ score: 10, streak: 3, totalProblems: 5, correctAnswers: 4 }),
+      }, 'End Game'),
+      createElement('button', {
+        'data-testid': 'exit-game',
+        onClick: () => onGameEnd(null),
+      }, 'Exit'),
+      createElement('button', {
+        'data-testid': 'trigger-level-up',
+        onClick: () => onLevelUp(currentLevel),
+      }, 'Level Up'),
+    ),
+  ResultScreen: ({ onPlayAgain, onExit }) =>
+    createElement('div', { 'data-testid': 'result-screen' },
+      createElement('button', { 'data-testid': 'play-again', onClick: onPlayAgain }, 'Play Again'),
+      createElement('button', { 'data-testid': 'exit-result', onClick: onExit }, 'Exit'),
+    ),
+  LevelUpScreen: ({ completedLevel, onContinue }) =>
+    createElement('div', {
+      'data-testid': 'levelup-screen',
+      'data-completed-level': completedLevel,
+    },
+      createElement('button', { 'data-testid': 'continue-level-up', onClick: onContinue }, 'Continue'),
+    ),
+  ProfileSwitcher: ({ onCreateProfile }) =>
+    createElement('div', { 'data-testid': 'profile-switcher' },
+      createElement('button', { 'data-testid': 'create-profile', onClick: onCreateProfile }, 'Create'),
+    ),
+  CreateProfile: ({ onComplete, onCancel }) =>
+    createElement('div', { 'data-testid': 'create-profile-wizard' },
+      createElement('button', {
+        'data-testid': 'complete-wizard',
+        onClick: () => onComplete({
+          id: 'new-1', nickname: 'Hero', theme: 'sonic',
+          pinHash: 'a'.repeat(64), firebaseUid: 'fb-uid', currentLevel: 1,
+        }),
+      }, 'Complete'),
+      createElement('button', { 'data-testid': 'cancel-wizard', onClick: onCancel }, 'Cancel'),
+    ),
+}))
+
+// Import App after mocks are in place
+const { default: App } = await import('../../App')
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+/** Standard active profile at a given level */
+function setProfile(level = 1) {
+  mockProfileCtx.activeProfile = {
+    id: 'profile-1',
+    nickname: 'Dubi',
+    firebaseUid: 'uid-1',
+    currentLevel: level,
+  }
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe('Level Progression Integration', () => {
+  beforeEach(() => {
+    cleanup()
+    vi.clearAllMocks()
+    mockProfileCtx.activeProfile = null
+    mockProfileCtx.isLoading = false
+    mockProfileCtx.clearActiveProfile = vi.fn()
+    mockProfileCtx.createAndActivate = vi.fn()
+    mockProfileCtx.updateProfile = vi.fn()
+    mockFirebase.user = { uid: 'test-uid' }
+    mockFirebase.loading = false
+    mockFirebase.error = null
+  })
+
+  // ── 1. Complete level-up flow ──────────────────────────────────────────
+
+  describe('complete level-up flow (start -> game -> level-up -> continue -> game)', () => {
+    it('navigates through the full level-up lifecycle', () => {
+      setProfile(3)
+      render(<App />)
+
+      // Step 1: StartScreen visible at level 3
+      expect(screen.getByTestId('start-screen')).toBeTruthy()
+      expect(screen.getByTestId('start-screen').getAttribute('data-current-level')).toBe('3')
+
+      // Step 2: Start the game
+      fireEvent.click(screen.getByTestId('start-game'))
+      expect(screen.getByTestId('game-screen')).toBeTruthy()
+      expect(screen.queryByTestId('start-screen')).toBeNull()
+
+      // Step 3: Trigger level-up from GameScreen
+      fireEvent.click(screen.getByTestId('trigger-level-up'))
+      expect(screen.getByTestId('levelup-screen')).toBeTruthy()
+      expect(screen.queryByTestId('game-screen')).toBeNull()
+
+      // Step 4: Verify completedLevel is passed correctly
+      expect(screen.getByTestId('levelup-screen').getAttribute('data-completed-level')).toBe('3')
+
+      // Step 5: Click Continue -> profile updated + back to game
+      fireEvent.click(screen.getByTestId('continue-level-up'))
+      expect(mockProfileCtx.updateProfile).toHaveBeenCalledTimes(1)
+      expect(mockProfileCtx.updateProfile).toHaveBeenCalledWith('profile-1', { currentLevel: 4 })
+      expect(screen.getByTestId('game-screen')).toBeTruthy()
+      expect(screen.queryByTestId('levelup-screen')).toBeNull()
+    })
+
+    it('updates profile with incremented currentLevel for each mid-range level', () => {
+      const testCases = [
+        { from: 1, to: 2 },
+        { from: 6, to: 7 },
+        { from: 12, to: 13 },
+      ]
+
+      testCases.forEach(({ from, to }) => {
+        cleanup()
+        vi.clearAllMocks()
+        setProfile(from)
+
+        render(<App />)
+        fireEvent.click(screen.getByTestId('start-game'))
+        fireEvent.click(screen.getByTestId('trigger-level-up'))
+        fireEvent.click(screen.getByTestId('continue-level-up'))
+
+        expect(mockProfileCtx.updateProfile).toHaveBeenCalledWith('profile-1', { currentLevel: to })
+      })
+    })
+  })
+
+  // ── 2. Max level (champion) flow ───────────────────────────────────────
+
+  describe('max level flow (champion at level 13)', () => {
+    it('shows champion celebration screen at max level', () => {
+      setProfile(13)
+      render(<App />)
+
+      fireEvent.click(screen.getByTestId('start-game'))
+      fireEvent.click(screen.getByTestId('trigger-level-up'))
+
+      expect(screen.getByTestId('levelup-screen')).toBeTruthy()
+      expect(screen.getByTestId('levelup-screen').getAttribute('data-completed-level')).toBe('13')
+    })
+
+    it('does NOT call updateProfile with level 14 when at max level', () => {
+      setProfile(13)
+      render(<App />)
+
+      fireEvent.click(screen.getByTestId('start-game'))
+      fireEvent.click(screen.getByTestId('trigger-level-up'))
+      fireEvent.click(screen.getByTestId('continue-level-up'))
+
+      // updateProfile should NOT be called at all (nextLevel=14 > MAX_LEVEL=13)
+      expect(mockProfileCtx.updateProfile).not.toHaveBeenCalled()
+    })
+
+    it('returns to game screen after champion celebration', () => {
+      setProfile(13)
+      render(<App />)
+
+      fireEvent.click(screen.getByTestId('start-game'))
+      fireEvent.click(screen.getByTestId('trigger-level-up'))
+      fireEvent.click(screen.getByTestId('continue-level-up'))
+
+      expect(screen.getByTestId('game-screen')).toBeTruthy()
+      expect(screen.queryByTestId('levelup-screen')).toBeNull()
+    })
+
+    it('stays at level 13 in GameScreen after champion continue', () => {
+      setProfile(13)
+      render(<App />)
+
+      fireEvent.click(screen.getByTestId('start-game'))
+      fireEvent.click(screen.getByTestId('trigger-level-up'))
+      fireEvent.click(screen.getByTestId('continue-level-up'))
+
+      // GameScreen should still receive currentLevel=13
+      const gameScreen = screen.getByTestId('game-screen')
+      expect(gameScreen.getAttribute('data-current-level')).toBe('13')
+    })
+  })
+
+  // ── 3. Level map reflects progress ─────────────────────────────────────
+
+  describe('level map reflects current progress on StartScreen', () => {
+    it('passes currentLevel to StartScreen for LevelMap rendering', () => {
+      setProfile(5)
+      render(<App />)
+
+      const startScreen = screen.getByTestId('start-screen')
+      expect(startScreen.getAttribute('data-current-level')).toBe('5')
+    })
+
+    it('passes currentLevel=1 when profile has no currentLevel set', () => {
+      mockProfileCtx.activeProfile = {
+        id: 'profile-1',
+        nickname: 'Dubi',
+        firebaseUid: 'uid-1',
+        // no currentLevel — should default to 1
+      }
+      render(<App />)
+
+      const startScreen = screen.getByTestId('start-screen')
+      expect(startScreen.getAttribute('data-current-level')).toBe('1')
+    })
+
+    it('passes currentLevel=13 for max-level profile', () => {
+      setProfile(13)
+      render(<App />)
+
+      const startScreen = screen.getByTestId('start-screen')
+      expect(startScreen.getAttribute('data-current-level')).toBe('13')
+    })
+  })
+
+  // ── 4. Persistence — level-up saves to profile ─────────────────────────
+
+  describe('persistence through profile update', () => {
+    it('calls updateProfile exactly once per level-up continue', () => {
+      setProfile(5)
+      render(<App />)
+
+      fireEvent.click(screen.getByTestId('start-game'))
+      fireEvent.click(screen.getByTestId('trigger-level-up'))
+      fireEvent.click(screen.getByTestId('continue-level-up'))
+
+      expect(mockProfileCtx.updateProfile).toHaveBeenCalledTimes(1)
+      expect(mockProfileCtx.updateProfile).toHaveBeenCalledWith('profile-1', { currentLevel: 6 })
+    })
+
+    it('does not call updateProfile when transitioning to levelup screen (only on continue)', () => {
+      setProfile(3)
+      render(<App />)
+
+      fireEvent.click(screen.getByTestId('start-game'))
+      fireEvent.click(screen.getByTestId('trigger-level-up'))
+
+      // At this point we are on the levelup screen but have not clicked continue
+      expect(mockProfileCtx.updateProfile).not.toHaveBeenCalled()
+    })
+
+    it('does not call updateProfile when exiting the game without level-up', () => {
+      setProfile(3)
+      render(<App />)
+
+      fireEvent.click(screen.getByTestId('start-game'))
+      fireEvent.click(screen.getByTestId('exit-game'))
+
+      expect(mockProfileCtx.updateProfile).not.toHaveBeenCalled()
+    })
+
+    it('does not call updateProfile when game ends normally (result screen)', () => {
+      setProfile(3)
+      render(<App />)
+
+      fireEvent.click(screen.getByTestId('start-game'))
+      fireEvent.click(screen.getByTestId('end-game'))
+
+      expect(screen.getByTestId('result-screen')).toBeTruthy()
+      expect(mockProfileCtx.updateProfile).not.toHaveBeenCalled()
+    })
+
+    it('calls forceSave when exiting from start screen via switch profile', () => {
+      setProfile(3)
+      render(<App />)
+
+      fireEvent.click(screen.getByTestId('switch-profile'))
+      expect(mockForceSave).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  // ── 5. Reduced motion ─────────────────────────────────────────────────
+
+  describe('reduced-motion (animation classes)', () => {
+    // These tests verify that the real LevelUpScreen and LevelMap components
+    // apply motion-reduce classes. Since we mock child components in this
+    // integration test, we test the actual components directly here.
+
+    it('LevelUpScreen hero emoji respects reduced motion', async () => {
+      // Import the real LevelUpScreen for this specific check
+      const { default: LevelUpScreen } = await import('../LevelUpScreen')
+      render(<LevelUpScreen completedLevel={1} onContinue={vi.fn()} />)
+
+      const hero = screen.getByTestId('hero-emoji')
+      expect(hero.className).toContain('motion-reduce:animate-none')
+    })
+
+    it('LevelUpScreen confetti particles respect reduced motion', async () => {
+      cleanup()
+      const { default: LevelUpScreen } = await import('../LevelUpScreen')
+      render(<LevelUpScreen completedLevel={1} onContinue={vi.fn()} />)
+
+      const particles = screen.getAllByTestId('confetti-particle')
+      particles.forEach((particle) => {
+        expect(particle.className).toContain('motion-reduce:hidden')
+      })
+    })
+
+    it('LevelMap current node pulse respects reduced motion', async () => {
+      cleanup()
+      // Mock scrollIntoView for happy-dom
+      Element.prototype.scrollIntoView = vi.fn()
+      const { default: LevelMap } = await import('../LevelMap')
+      render(<LevelMap currentLevel={5} />)
+
+      const currentNode = screen.getByTestId('level-node-5')
+      const pulsingEl = currentNode.querySelector('.animate-pulse-gold')
+      expect(pulsingEl.className).toContain('motion-reduce:animate-none')
+    })
+  })
+
+  // ── 6. Screen state isolation ──────────────────────────────────────────
+
+  describe('screen state isolation', () => {
+    it('only one screen is visible at a time during level-up flow', () => {
+      setProfile(5)
+      render(<App />)
+
+      // StartScreen only
+      expect(screen.getByTestId('start-screen')).toBeTruthy()
+      expect(screen.queryByTestId('game-screen')).toBeNull()
+      expect(screen.queryByTestId('levelup-screen')).toBeNull()
+      expect(screen.queryByTestId('result-screen')).toBeNull()
+
+      // GameScreen only
+      fireEvent.click(screen.getByTestId('start-game'))
+      expect(screen.queryByTestId('start-screen')).toBeNull()
+      expect(screen.getByTestId('game-screen')).toBeTruthy()
+      expect(screen.queryByTestId('levelup-screen')).toBeNull()
+      expect(screen.queryByTestId('result-screen')).toBeNull()
+
+      // LevelUpScreen only
+      fireEvent.click(screen.getByTestId('trigger-level-up'))
+      expect(screen.queryByTestId('start-screen')).toBeNull()
+      expect(screen.queryByTestId('game-screen')).toBeNull()
+      expect(screen.getByTestId('levelup-screen')).toBeTruthy()
+      expect(screen.queryByTestId('result-screen')).toBeNull()
+
+      // Back to GameScreen only
+      fireEvent.click(screen.getByTestId('continue-level-up'))
+      expect(screen.queryByTestId('start-screen')).toBeNull()
+      expect(screen.getByTestId('game-screen')).toBeTruthy()
+      expect(screen.queryByTestId('levelup-screen')).toBeNull()
+      expect(screen.queryByTestId('result-screen')).toBeNull()
+    })
+
+    it('completedLevel state is cleared after continue', () => {
+      setProfile(5)
+      render(<App />)
+
+      fireEvent.click(screen.getByTestId('start-game'))
+      fireEvent.click(screen.getByTestId('trigger-level-up'))
+
+      // completedLevel = 5
+      expect(screen.getByTestId('levelup-screen').getAttribute('data-completed-level')).toBe('5')
+
+      // After continue, levelup screen is gone (completedLevel cleared)
+      fireEvent.click(screen.getByTestId('continue-level-up'))
+      expect(screen.queryByTestId('levelup-screen')).toBeNull()
+    })
+  })
+
+  // ── 7. Boundary level transitions ─────────────────────────────────────
+
+  describe('boundary level transitions', () => {
+    it('level 1 -> 2: first level-up ever', () => {
+      setProfile(1)
+      render(<App />)
+
+      fireEvent.click(screen.getByTestId('start-game'))
+      fireEvent.click(screen.getByTestId('trigger-level-up'))
+      fireEvent.click(screen.getByTestId('continue-level-up'))
+
+      expect(mockProfileCtx.updateProfile).toHaveBeenCalledWith('profile-1', { currentLevel: 2 })
+    })
+
+    it('level 12 -> 13: last normal level-up', () => {
+      setProfile(12)
+      render(<App />)
+
+      fireEvent.click(screen.getByTestId('start-game'))
+      fireEvent.click(screen.getByTestId('trigger-level-up'))
+
+      // Should show normal celebration (not champion)
+      expect(screen.getByTestId('levelup-screen').getAttribute('data-completed-level')).toBe('12')
+
+      fireEvent.click(screen.getByTestId('continue-level-up'))
+      expect(mockProfileCtx.updateProfile).toHaveBeenCalledWith('profile-1', { currentLevel: 13 })
+    })
+
+    it('level 13 (max): no profile update beyond max', () => {
+      setProfile(13)
+      render(<App />)
+
+      fireEvent.click(screen.getByTestId('start-game'))
+      fireEvent.click(screen.getByTestId('trigger-level-up'))
+      fireEvent.click(screen.getByTestId('continue-level-up'))
+
+      expect(mockProfileCtx.updateProfile).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/src/components/aids/LearningAid.jsx
+++ b/src/components/aids/LearningAid.jsx
@@ -29,17 +29,25 @@ import StrategyHint from './StrategyHint'
 /** Maximum level that shows the DotCounter aid */
 const DOT_COUNTER_MAX_LEVEL = 4
 
+/** Operators that DotCounter and NumberLine support */
+const VISUAL_AID_OPERATORS = new Set(['+', '-'])
+
 /**
- * Select the aid component for a given level.
+ * Select the aid component for a given level and operator.
+ *
+ * DotCounter (levels 1-4) only supports + and -. For * and / operators
+ * at those levels, fall through to StrategyHint instead.
  *
  * @param {number} level
+ * @param {string} operator - '+', '-', '*', or '/'
  * @returns {Function|null} React component or null
  */
-function selectAid(level) {
-  if (level >= 1 && level <= DOT_COUNTER_MAX_LEVEL) {
+function selectAid(level, operator) {
+  if (level >= 1 && level <= DOT_COUNTER_MAX_LEVEL && VISUAL_AID_OPERATORS.has(operator)) {
     return DotCounter
   }
-  if (level >= DOT_COUNTER_MAX_LEVEL + 1) {
+  // Levels 5+ always use StrategyHint; levels 1-4 with * or / also fall through here
+  if (level >= 1) {
     return StrategyHint
   }
   return null
@@ -53,31 +61,31 @@ function LearningAid({ isStruggling, currentLevel, num1, num2, operator }) {
     return null
   }
 
-  const AidComponent = selectAid(currentLevel)
+  const AidComponent = selectAid(currentLevel, operator)
 
   // No aid available for this level tier
   if (!AidComponent) {
     return null
   }
 
-  const maxHeight = AidComponent === StrategyHint ? 'max-h-[160px]' : 'max-h-[120px]'
-
   return (
     <div
-      className={`
-        ${maxHeight} overflow-hidden
+      className="
+        flex flex-col max-h-[50vh]
         bg-black/20 backdrop-blur-sm rounded-2xl p-3
         animate-aid-enter motion-reduce:animate-none
-      `}
+      "
       data-testid="learning-aid-container"
     >
-      <AidComponent num1={num1} num2={num2} operator={operator} />
+      <div className="flex-1 overflow-y-auto min-h-0">
+        <AidComponent num1={num1} num2={num2} operator={operator} />
+      </div>
 
       <button
         type="button"
         onClick={() => setDismissed(true)}
         className="
-          mt-2 w-full min-h-[44px]
+          mt-2 w-full min-h-[44px] shrink-0
           bg-sonic-gold hover:bg-yellow-400
           text-black font-game text-base
           rounded-xl shadow-md

--- a/src/components/aids/LearningAid.test.jsx
+++ b/src/components/aids/LearningAid.test.jsx
@@ -222,22 +222,46 @@ describe('LearningAid', () => {
   // ── Container Styling ──────────────────────────────────────────────────
 
   describe('container styling', () => {
-    it('has max-h-[120px] class for DotCounter', () => {
+    it('has max-h-[50vh] class for both DotCounter and StrategyHint', () => {
       renderAid({ currentLevel: 2 })
-      const container = screen.getByTestId('learning-aid-container')
-      expect(container.className).toContain('max-h-[120px]')
-    })
+      const dotContainer = screen.getByTestId('learning-aid-container')
+      expect(dotContainer.className).toContain('max-h-[50vh]')
+      cleanup()
 
-    it('has max-h-[160px] class for StrategyHint', () => {
       renderAid({ currentLevel: 5, num1: 8, num2: 5, operator: '+' })
-      const container = screen.getByTestId('learning-aid-container')
-      expect(container.className).toContain('max-h-[160px]')
+      const strategyContainer = screen.getByTestId('learning-aid-container')
+      expect(strategyContainer.className).toContain('max-h-[50vh]')
     })
 
-    it('has overflow-hidden class', () => {
+    it('has flex flex-col layout on the container', () => {
       renderAid()
       const container = screen.getByTestId('learning-aid-container')
-      expect(container.className).toContain('overflow-hidden')
+      expect(container.className).toContain('flex')
+      expect(container.className).toContain('flex-col')
+    })
+
+    it('button is outside the scrollable area (not nested inside overflow container)', () => {
+      renderAid()
+      const container = screen.getByTestId('learning-aid-container')
+      const button = screen.getByTestId('dismiss-aid-button')
+      // Button should be a direct child of the container, not inside the scrollable div
+      expect(button.parentElement).toBe(container)
+    })
+
+    it('scrollable content area has overflow-y-auto and min-h-0', () => {
+      renderAid()
+      const container = screen.getByTestId('learning-aid-container')
+      // First child div is the scrollable area
+      const scrollArea = container.querySelector(':scope > div')
+      expect(scrollArea.className).toContain('overflow-y-auto')
+      expect(scrollArea.className).toContain('min-h-0')
+      expect(scrollArea.className).toContain('flex-1')
+    })
+
+    it('dismiss button has shrink-0 class', () => {
+      renderAid()
+      const button = screen.getByTestId('dismiss-aid-button')
+      expect(button.className).toContain('shrink-0')
     })
 
     it('has bg-black/20 backdrop-blur-sm class', () => {
@@ -374,6 +398,79 @@ describe('LearningAid', () => {
       const ol = hint.querySelector('ol')
       expect(ol).toBeTruthy()
       expect(ol.querySelectorAll('li').length).toBeGreaterThan(0)
+    })
+  })
+
+  // ── Multiplication / Division Support ─────────────────────────────────
+
+  describe('multiplication and division', () => {
+    it('renders StrategyHint for level 7 multiplication', () => {
+      renderAid({ currentLevel: 7, num1: 3, num2: 4, operator: '*' })
+      expect(screen.getByTestId('learning-aid-container')).toBeTruthy()
+      expect(screen.getByTestId('strategy-hint')).toBeTruthy()
+    })
+
+    it('renders StrategyHint for level 8 multiplication', () => {
+      renderAid({ currentLevel: 8, num1: 5, num2: 2, operator: '*' })
+      expect(screen.getByTestId('learning-aid-container')).toBeTruthy()
+      expect(screen.getByTestId('strategy-hint')).toBeTruthy()
+    })
+
+    it('renders StrategyHint for level 9 division', () => {
+      renderAid({ currentLevel: 9, num1: 12, num2: 3, operator: '/' })
+      expect(screen.getByTestId('learning-aid-container')).toBeTruthy()
+      expect(screen.getByTestId('strategy-hint')).toBeTruthy()
+    })
+
+    it('renders StrategyHint for level 10 division', () => {
+      renderAid({ currentLevel: 10, num1: 20, num2: 5, operator: '/' })
+      expect(screen.getByTestId('learning-aid-container')).toBeTruthy()
+      expect(screen.getByTestId('strategy-hint')).toBeTruthy()
+    })
+
+    it('falls through to StrategyHint at level 3 with * operator (DotCounter unsupported)', () => {
+      renderAid({ currentLevel: 3, num1: 2, num2: 3, operator: '*' })
+      expect(screen.getByTestId('learning-aid-container')).toBeTruthy()
+      expect(screen.getByTestId('strategy-hint')).toBeTruthy()
+      expect(screen.queryByTestId('dot-counter')).toBeNull()
+    })
+
+    it('falls through to StrategyHint at level 2 with / operator (DotCounter unsupported)', () => {
+      renderAid({ currentLevel: 2, num1: 6, num2: 2, operator: '/' })
+      expect(screen.getByTestId('learning-aid-container')).toBeTruthy()
+      expect(screen.getByTestId('strategy-hint')).toBeTruthy()
+      expect(screen.queryByTestId('dot-counter')).toBeNull()
+    })
+
+    it('dismiss works with multiplication StrategyHint', () => {
+      renderAid({ currentLevel: 7, num1: 3, num2: 4, operator: '*' })
+      expect(screen.getByTestId('learning-aid-container')).toBeTruthy()
+      expect(screen.getByTestId('strategy-hint')).toBeTruthy()
+
+      fireEvent.click(screen.getByTestId('dismiss-aid-button'))
+
+      expect(screen.queryByTestId('learning-aid-container')).toBeNull()
+    })
+
+    it('dismiss works with division StrategyHint', () => {
+      renderAid({ currentLevel: 9, num1: 12, num2: 3, operator: '/' })
+      expect(screen.getByTestId('learning-aid-container')).toBeTruthy()
+
+      fireEvent.click(screen.getByTestId('dismiss-aid-button'))
+
+      expect(screen.queryByTestId('learning-aid-container')).toBeNull()
+    })
+
+    it('passes multiplication props to StrategyHint aria-label', () => {
+      renderAid({ currentLevel: 7, num1: 3, num2: 4, operator: '*' })
+      const hint = screen.getByTestId('strategy-hint')
+      expect(hint.getAttribute('aria-label')).toBe('Strategy hint for 3 * 4')
+    })
+
+    it('passes division props to StrategyHint aria-label', () => {
+      renderAid({ currentLevel: 9, num1: 12, num2: 3, operator: '/' })
+      const hint = screen.getByTestId('strategy-hint')
+      expect(hint.getAttribute('aria-label')).toBe('Strategy hint for 12 / 3')
     })
   })
 })

--- a/src/components/aids/StrategyHint.jsx
+++ b/src/components/aids/StrategyHint.jsx
@@ -12,7 +12,7 @@
  * @param {Object} props
  * @param {number} props.num1      Left operand
  * @param {number} props.num2      Right operand
- * @param {string} props.operator  '+' or '-'
+ * @param {string} props.operator  '+', '-', '*', or '/'
  */
 
 import { useState, useEffect } from 'react'
@@ -100,7 +100,7 @@ function StrategyHint({ num1, num2, operator }) {
 StrategyHint.propTypes = {
   num1: PropTypes.number.isRequired,
   num2: PropTypes.number.isRequired,
-  operator: PropTypes.oneOf(['+', '-']).isRequired,
+  operator: PropTypes.oneOf(['+', '-', '*', '/']).isRequired,
 }
 
 export default StrategyHint

--- a/src/components/aids/StrategyHint.test.jsx
+++ b/src/components/aids/StrategyHint.test.jsx
@@ -214,26 +214,109 @@ describe('StrategyHint', () => {
     })
   })
 
-  // ── Empty Strategies (null return) ────────────────────────────────────
+  // ── Multiplication Rendering ─────────────────────────────────────────
 
-  describe('empty strategies', () => {
-    it('returns null for multiplication operator', () => {
-      const { container } = render(
-        <StrategyHint num1={6} num2={3} operator="*" />,
-      )
-      expect(container.innerHTML).toBe('')
+  describe('multiplication', () => {
+    it('renders strategies for multiplication problems', () => {
+      renderStrategyHint({ num1: 3, num2: 4, operator: '*' })
+      expect(screen.getByTestId('strategy-hint')).toBeTruthy()
     })
 
-    it('returns null for division operator', () => {
-      const { container } = render(
-        <StrategyHint num1={6} num2={3} operator="/" />,
-      )
-      expect(container.innerHTML).toBe('')
+    it('shows strategy name for 3*4', () => {
+      renderStrategyHint({ num1: 3, num2: 4, operator: '*' })
+      const strategies = getStrategies(3, 4, '*')
+      expect(strategies.length).toBeGreaterThan(0)
+      expect(screen.getByText(strategies[0].name)).toBeTruthy()
     })
 
-    it('does not render strategy-hint testid for unsupported operators', () => {
-      render(<StrategyHint num1={6} num2={3} operator="*" />)
-      expect(screen.queryByTestId('strategy-hint')).toBeNull()
+    it('renders steps for multiplication strategy', () => {
+      renderStrategyHint({ num1: 3, num2: 4, operator: '*' })
+      const strategies = getStrategies(3, 4, '*')
+      for (const step of strategies[0].steps) {
+        expect(screen.getByText(step)).toBeTruthy()
+      }
+    })
+
+    it('renders strategy counter for multiplication', () => {
+      renderStrategyHint({ num1: 3, num2: 4, operator: '*' })
+      const strategies = getStrategies(3, 4, '*')
+      expect(
+        screen.getByText(`Strategy 1 of ${strategies.length}`),
+      ).toBeTruthy()
+    })
+
+    it('renders times-ten strategy for 6*10', () => {
+      renderStrategyHint({ num1: 6, num2: 10, operator: '*' })
+      expect(screen.getByText('Times Ten')).toBeTruthy()
+    })
+
+    it('renders doubles strategy for 5*2', () => {
+      renderStrategyHint({ num1: 5, num2: 2, operator: '*' })
+      const strategies = getStrategies(5, 2, '*')
+      expect(strategies.some(s => s.name === 'Use Doubles')).toBe(true)
+    })
+
+    it('shows "Show me another way" when multiple mult strategies exist', () => {
+      // 5*2 triggers doubles-mult + repeated-addition + commutative
+      renderStrategyHint({ num1: 5, num2: 2, operator: '*' })
+      const strategies = getStrategies(5, 2, '*')
+      expect(strategies.length).toBeGreaterThan(1)
+      expect(
+        screen.getByRole('button', { name: /show me another way/i }),
+      ).toBeTruthy()
+    })
+  })
+
+  // ── Division Rendering ──────────────────────────────────────────────
+
+  describe('division', () => {
+    it('renders strategies for division problems', () => {
+      renderStrategyHint({ num1: 12, num2: 3, operator: '/' })
+      expect(screen.getByTestId('strategy-hint')).toBeTruthy()
+    })
+
+    it('shows strategy name for 12/3', () => {
+      renderStrategyHint({ num1: 12, num2: 3, operator: '/' })
+      const strategies = getStrategies(12, 3, '/')
+      expect(strategies.length).toBeGreaterThan(0)
+      expect(screen.getByText(strategies[0].name)).toBeTruthy()
+    })
+
+    it('renders steps for division strategy', () => {
+      renderStrategyHint({ num1: 12, num2: 3, operator: '/' })
+      const strategies = getStrategies(12, 3, '/')
+      for (const step of strategies[0].steps) {
+        expect(screen.getByText(step)).toBeTruthy()
+      }
+    })
+
+    it('renders halving strategy for 12/2', () => {
+      renderStrategyHint({ num1: 12, num2: 2, operator: '/' })
+      expect(screen.getByText('Halving')).toBeTruthy()
+    })
+
+    it('renders inverse-mult strategy for 20/5', () => {
+      renderStrategyHint({ num1: 20, num2: 5, operator: '/' })
+      expect(screen.getByText('Think Multiplication')).toBeTruthy()
+    })
+
+    it('shows "Show me another way" for 12/2 (halving + inverse-mult)', () => {
+      renderStrategyHint({ num1: 12, num2: 2, operator: '/' })
+      const strategies = getStrategies(12, 2, '/')
+      expect(strategies.length).toBe(2)
+      expect(
+        screen.getByRole('button', { name: /show me another way/i }),
+      ).toBeTruthy()
+    })
+
+    it('cycles through division strategies', () => {
+      renderStrategyHint({ num1: 12, num2: 2, operator: '/' })
+      const strategies = getStrategies(12, 2, '/')
+      expect(screen.getByText(`Strategy 1 of ${strategies.length}`)).toBeTruthy()
+
+      const button = screen.getByRole('button', { name: /show me another way/i })
+      fireEvent.click(button)
+      expect(screen.getByText(`Strategy 2 of ${strategies.length}`)).toBeTruthy()
     })
   })
 

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -9,6 +9,7 @@
  * - GameScreen: Main game interface composing all components
  * - StartScreen: Welcome screen before game starts
  * - ResultScreen: End game summary with stats
+ * - LevelMap: Horizontal scrollable level progress visualization
  * - ProfileSwitcher: Avatar card grid for selecting profiles
  * - PinEntry: 4-dot numpad PIN overlay (presentational)
  * - CreateProfile: 4-step wizard for creating new profiles
@@ -22,6 +23,7 @@ export { default as Feedback } from './Feedback'
 export { default as GameScreen } from './GameScreen'
 export { default as StartScreen } from './StartScreen'
 export { default as ResultScreen } from './ResultScreen'
+export { default as LevelMap } from './LevelMap'
 export { default as ProfileSwitcher } from './ProfileSwitcher'
 export { default as PinEntry } from './PinEntry'
 export { default as CreateProfile } from './CreateProfile'

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -12,6 +12,7 @@
  * - ProfileSwitcher: Avatar card grid for selecting profiles
  * - PinEntry: 4-dot numpad PIN overlay (presentational)
  * - CreateProfile: 4-step wizard for creating new profiles
+ * - LevelUpScreen: Celebration screen when player levels up
  */
 
 export { default as Problem } from './Problem'
@@ -24,3 +25,4 @@ export { default as ResultScreen } from './ResultScreen'
 export { default as ProfileSwitcher } from './ProfileSwitcher'
 export { default as PinEntry } from './PinEntry'
 export { default as CreateProfile } from './CreateProfile'
+export { default as LevelUpScreen } from './LevelUpScreen'

--- a/src/config/levels.js
+++ b/src/config/levels.js
@@ -1,3 +1,6 @@
+/** Total number of levels — use this instead of magic number 13 */
+export const MAX_LEVEL = 13
+
 export const LEVELS = [
   { id: 1,  name: 'First Steps',     operators: ['+'],           minNumber: 1, maxNumber: 5,   ageTarget: '5-6'  },
   { id: 2,  name: 'Addition Hero',   operators: ['+'],           minNumber: 1, maxNumber: 10,  ageTarget: '6'    },

--- a/src/config/themes.js
+++ b/src/config/themes.js
@@ -1,0 +1,38 @@
+/**
+ * Theme configuration for Math Trainer
+ *
+ * Defines hero-specific branding (titles, emojis, messages) so that
+ * downstream components can render themed content based on the
+ * player's chosen hero profile.
+ *
+ * Each theme key must match the `theme` field stored on a profile object.
+ */
+
+export const THEMES = {
+  sonic: {
+    name: 'Sonic',
+    emoji: '\u{1F994}\u{1F4A8}',       // hedgehog + dash
+    titlePrefix: 'Sonic',
+    streakEmoji: '\u{1F994}',            // hedgehog
+    correctMessage: 'Sonic Speed!',
+    amazingMessage: 'Sonic Speed! Amazing!',
+  },
+  spiderman: {
+    name: 'Spiderman',
+    emoji: '\u{1F577}\u{FE0F}\u{1F578}\u{FE0F}', // spider + web
+    titlePrefix: 'Spiderman',
+    streakEmoji: '\u{1F577}\u{FE0F}',   // spider
+    correctMessage: 'Spider Sense!',
+    amazingMessage: 'Spider Power! Amazing!',
+  },
+}
+
+export const DEFAULT_THEME = 'sonic'
+
+/**
+ * Returns the theme object for the given key, falling back to sonic.
+ *
+ * @param {string} themeKey - Key into THEMES (e.g. 'sonic', 'spiderman')
+ * @returns {object} Theme configuration object
+ */
+export const getTheme = (themeKey) => THEMES[themeKey] || THEMES[DEFAULT_THEME]

--- a/src/hooks/useConfidence.js
+++ b/src/hooks/useConfidence.js
@@ -26,7 +26,7 @@ export const STRUGGLING_THRESHOLD = 35
 export const CRITICAL_THRESHOLD = 20
 export const CRITICAL_CONSECUTIVE_WRONG = 5
 export const LEVEL_UP_THRESHOLD = 85
-export const LEVEL_UP_CONSECUTIVE_CORRECT = 3
+export const LEVEL_UP_CONSECUTIVE_CORRECT = 5
 export const DEFAULT_INITIAL_SCORE = 50
 
 // --- Action Types ---
@@ -173,7 +173,7 @@ function confidenceReducer(state, action) {
  * @returns {number} returns.consecutiveWrong - Consecutive wrong answers
  * @returns {boolean} returns.isStruggling - True when score < 35
  * @returns {boolean} returns.isCritical - True when score < 20 AND consecutiveWrong >= 5
- * @returns {boolean} returns.shouldLevelUp - True when score >= 85 AND streak >= 3 (sticky)
+ * @returns {boolean} returns.shouldLevelUp - True when score >= 85 AND streak >= 5 (sticky)
  * @returns {number} returns.lastDelta - Last score change for UI animations
  * @returns {Function} returns.recordAnswer - (isCorrect, responseTimeMs) => void
  * @returns {Function} returns.acknowledgeLevelUp - () => void

--- a/src/hooks/useConfidence.test.js
+++ b/src/hooks/useConfidence.test.js
@@ -56,7 +56,7 @@ describe('useConfidence - exported constants', () => {
     expect(CRITICAL_THRESHOLD).toBe(20)
     expect(CRITICAL_CONSECUTIVE_WRONG).toBe(5)
     expect(LEVEL_UP_THRESHOLD).toBe(85)
-    expect(LEVEL_UP_CONSECUTIVE_CORRECT).toBe(3)
+    expect(LEVEL_UP_CONSECUTIVE_CORRECT).toBe(5)
     expect(DEFAULT_INITIAL_SCORE).toBe(50)
   })
 })
@@ -335,25 +335,27 @@ describe('useConfidence - isCritical flag', () => {
 // Threshold Flags — shouldLevelUp (sticky)
 // =============================================================
 describe('useConfidence - shouldLevelUp flag', () => {
-  it('should become true when score >= 85 AND streak >= 3', () => {
+  it('should become true when score >= 85 AND streak >= 5', () => {
     const { result } = renderHook(() => useConfidence(80))
-    // Need score >= 85 and streak >= 3
-    // 1st correct: +8  = 88, streak=1 → not yet
-    // 2nd correct: +10 = 98, streak=2 → not yet
-    // 3rd correct: +10 = 100 (clamped), streak=3 → LEVEL UP
-    recordCorrect(result, 3)
+    // Need score >= 85 and streak >= 5
+    // 1st correct: +8  = 88, streak=1
+    // 2nd correct: +10 = 98, streak=2
+    // 3rd correct: +10 = 100, streak=3
+    // 4th correct: +10 = 100, streak=4
+    // 5th correct: +10 = 100, streak=5 → LEVEL UP
+    recordCorrect(result, 5)
     expect(result.current.shouldLevelUp).toBe(true)
   })
 
-  it('should NOT trigger if score >= 85 but streak < 3', () => {
+  it('should NOT trigger if score >= 85 but streak < 5', () => {
     const { result } = renderHook(() => useConfidence(90))
-    recordCorrect(result, 1) // streak=1, score=98
+    recordCorrect(result, 4) // streak=4, score=100
     expect(result.current.shouldLevelUp).toBe(false)
   })
 
   it('should be sticky — stays true even after wrong answers', () => {
     const { result } = renderHook(() => useConfidence(80))
-    recordCorrect(result, 3) // triggers shouldLevelUp
+    recordCorrect(result, 5) // triggers shouldLevelUp
     expect(result.current.shouldLevelUp).toBe(true)
 
     recordWrong(result, 1) // score drops, streak resets
@@ -362,7 +364,7 @@ describe('useConfidence - shouldLevelUp flag', () => {
 
   it('should be cleared by acknowledgeLevelUp()', () => {
     const { result } = renderHook(() => useConfidence(80))
-    recordCorrect(result, 3)
+    recordCorrect(result, 5)
     expect(result.current.shouldLevelUp).toBe(true)
 
     act(() => {
@@ -373,14 +375,14 @@ describe('useConfidence - shouldLevelUp flag', () => {
 
   it('should not re-trigger until conditions are met again after acknowledgement', () => {
     const { result } = renderHook(() => useConfidence(80))
-    recordCorrect(result, 3) // triggers level up
+    recordCorrect(result, 5) // triggers level up
     act(() => {
       result.current.acknowledgeLevelUp()
     })
     expect(result.current.shouldLevelUp).toBe(false)
 
-    // One more correct — streak=4, score=100, but shouldLevelUp was cleared
-    // Streak >= 3 and score >= 85, so it re-triggers
+    // One more correct — streak=6, score=100, but shouldLevelUp was cleared
+    // Streak >= 5 and score >= 85, so it re-triggers
     recordCorrect(result, 1)
     expect(result.current.shouldLevelUp).toBe(true)
   })
@@ -392,7 +394,7 @@ describe('useConfidence - shouldLevelUp flag', () => {
 describe('useConfidence - reset', () => {
   it('should reset to DEFAULT_INITIAL_SCORE when called without args', () => {
     const { result } = renderHook(() => useConfidence(80))
-    recordCorrect(result, 3)
+    recordCorrect(result, 5)
     act(() => {
       result.current.reset()
     })
@@ -426,7 +428,7 @@ describe('useConfidence - reset', () => {
 
   it('should clear shouldLevelUp on reset', () => {
     const { result } = renderHook(() => useConfidence(80))
-    recordCorrect(result, 3)
+    recordCorrect(result, 5)
     expect(result.current.shouldLevelUp).toBe(true)
     act(() => {
       result.current.reset()

--- a/src/hooks/useGameState.js
+++ b/src/hooks/useGameState.js
@@ -8,7 +8,7 @@
  * - Integrates with useGameProgress for Firestore persistence
  *
  * @param {Object} options - Hook options
- * @param {number} options.currentLevel - Current difficulty level (default: 2)
+ * @param {number} options.currentLevel - Current difficulty level (default: 1, clamped 1-13)
  * @param {Function} options.updateProgress - Function from useGameProgress to persist data
  * @param {Object} options.initialProgress - Initial progress data from Firestore
  * @returns {Object} Game state and control functions
@@ -17,13 +17,26 @@
 import { useState, useCallback, useRef, useEffect } from 'react'
 import { generateProblem, validateAnswer } from '../utils/mathProblems'
 import { useConfidence } from './useConfidence'
-import { getLevelConfig } from '../config/levels'
+import { getLevelConfig, LEVELS } from '../config/levels'
 
 // Feedback display duration (ms)
 const FEEDBACK_DURATION_MS = 2000
 
 // Points awarded for correct answer
 const POINTS_PER_CORRECT = 10
+
+// Valid level range boundaries
+const MIN_LEVEL = 1
+const MAX_LEVEL = LEVELS.length
+
+/**
+ * Clamp a level value to the valid range [1, LEVELS.length].
+ * @param {number} level
+ * @returns {number}
+ */
+function clampLevel(level) {
+  return Math.max(MIN_LEVEL, Math.min(MAX_LEVEL, Math.floor(level)))
+}
 
 /**
  * Default game state
@@ -45,12 +58,15 @@ const DEFAULT_GAME_STATE = {
  * Custom hook for managing game state
  *
  * @param {Object} options - Configuration options
- * @param {number} options.currentLevel - Difficulty level (default: 2)
+ * @param {number} options.currentLevel - Difficulty level (default: 1). Clamped to 1-13.
  * @param {Function} options.updateProgress - Callback to persist progress to Firestore
  * @param {Object} options.initialProgress - Initial progress from Firestore
  * @returns {Object} Game state and control functions
  */
-export function useGameState({ currentLevel = 2, updateProgress, initialProgress } = {}) {
+export function useGameState({ currentLevel = 1, updateProgress, initialProgress } = {}) {
+  // Clamp to valid range so getLevelConfig never throws
+  const safeLevel = clampLevel(currentLevel)
+
   // Compose confidence engine (unconditional — rules of hooks)
   const confidence = useConfidence()
 
@@ -99,7 +115,7 @@ export function useGameState({ currentLevel = 2, updateProgress, initialProgress
    * Generates first problem and sets isPlaying to true
    */
   const startGame = useCallback(() => {
-    const firstProblem = generateProblem(getLevelConfig(currentLevel))
+    const firstProblem = generateProblem(getLevelConfig(safeLevel))
 
     confidence.reset()
     problemStartTimeRef.current = Date.now()
@@ -114,7 +130,7 @@ export function useGameState({ currentLevel = 2, updateProgress, initialProgress
       score: 0, // Reset score for new session
       streak: 0, // Reset current streak on new game
     }))
-  }, [currentLevel, confidence])
+  }, [safeLevel, confidence])
 
   /**
    * Generate and display next problem
@@ -123,7 +139,7 @@ export function useGameState({ currentLevel = 2, updateProgress, initialProgress
   const nextProblem = useCallback(() => {
     if (!isMountedRef.current) return
 
-    const newProblem = generateProblem(getLevelConfig(currentLevel))
+    const newProblem = generateProblem(getLevelConfig(safeLevel))
 
     problemStartTimeRef.current = Date.now()
 
@@ -134,7 +150,7 @@ export function useGameState({ currentLevel = 2, updateProgress, initialProgress
       showFeedback: false,
       isCorrect: false,
     }))
-  }, [currentLevel])
+  }, [safeLevel])
 
   /**
    * Process user's answer

--- a/src/hooks/useGameState.test.js
+++ b/src/hooks/useGameState.test.js
@@ -18,9 +18,16 @@ vi.mock('../utils/mathProblems', () => ({
 
 // Mock getLevelConfig so tests don't depend on real level data
 vi.mock('../config/levels', () => ({
+  LEVELS: Array.from({ length: 13 }, (_, i) => ({
+    id: i + 1,
+    name: `Level ${i + 1}`,
+    operators: ['+'],
+    minNumber: 1,
+    maxNumber: 10,
+  })),
   getLevelConfig: vi.fn((id) => ({
-    id: id ?? 2,
-    name: `Level ${id ?? 2}`,
+    id: id ?? 1,
+    name: `Level ${id ?? 1}`,
     operators: ['+'],
     minNumber: 1,
     maxNumber: 10,
@@ -313,7 +320,7 @@ describe('useGameState - confidence integration', () => {
     expect(getLevelConfig).toHaveBeenCalledWith(7)
   })
 
-  it('should default to level 2 when currentLevel not provided', () => {
+  it('should default to level 1 when currentLevel not provided', () => {
     getLevelConfig.mockClear()
 
     const { result } = renderHook(() => useGameState())
@@ -322,7 +329,7 @@ describe('useGameState - confidence integration', () => {
       result.current.startGame()
     })
 
-    expect(getLevelConfig).toHaveBeenCalledWith(2)
+    expect(getLevelConfig).toHaveBeenCalledWith(1)
   })
 
   it('should reset confidence on fullReset', () => {
@@ -552,5 +559,102 @@ describe('useGameState - response time integration', () => {
     // Score: 61 + 10 = 71
     expect(result.current.confidenceScore).toBe(71)
     expect(result.current.lastDelta).toBe(10)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// currentLevel prop threading & boundary clamping
+// ---------------------------------------------------------------------------
+
+describe('useGameState - currentLevel prop threading', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'))
+    getLevelConfig.mockClear()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('should pass the provided currentLevel to getLevelConfig on startGame', () => {
+    const { result } = renderHook(() => useGameState({ currentLevel: 5 }))
+
+    act(() => {
+      result.current.startGame()
+    })
+
+    expect(getLevelConfig).toHaveBeenCalledWith(5)
+  })
+
+  it('should pass the provided currentLevel to getLevelConfig on nextProblem', () => {
+    const { result } = renderHook(() => useGameState({ currentLevel: 9 }))
+
+    act(() => {
+      result.current.startGame()
+    })
+
+    getLevelConfig.mockClear()
+
+    // Answer correctly and advance past feedback to trigger nextProblem
+    vi.advanceTimersByTime(500)
+    act(() => {
+      result.current.handleAnswer(5)
+    })
+    act(() => {
+      vi.advanceTimersByTime(2000)
+    })
+
+    expect(getLevelConfig).toHaveBeenCalledWith(9)
+  })
+
+  it('should clamp currentLevel below 1 to 1', () => {
+    const { result } = renderHook(() => useGameState({ currentLevel: 0 }))
+
+    act(() => {
+      result.current.startGame()
+    })
+
+    expect(getLevelConfig).toHaveBeenCalledWith(1)
+  })
+
+  it('should clamp currentLevel above 13 to 13', () => {
+    const { result } = renderHook(() => useGameState({ currentLevel: 99 }))
+
+    act(() => {
+      result.current.startGame()
+    })
+
+    expect(getLevelConfig).toHaveBeenCalledWith(13)
+  })
+
+  it('should clamp negative currentLevel to 1', () => {
+    const { result } = renderHook(() => useGameState({ currentLevel: -5 }))
+
+    act(() => {
+      result.current.startGame()
+    })
+
+    expect(getLevelConfig).toHaveBeenCalledWith(1)
+  })
+
+  it('should floor fractional currentLevel values', () => {
+    const { result } = renderHook(() => useGameState({ currentLevel: 3.7 }))
+
+    act(() => {
+      result.current.startGame()
+    })
+
+    expect(getLevelConfig).toHaveBeenCalledWith(3)
+  })
+
+  it('should use level 13 config when currentLevel is exactly 13', () => {
+    const { result } = renderHook(() => useGameState({ currentLevel: 13 }))
+
+    act(() => {
+      result.current.startGame()
+    })
+
+    expect(getLevelConfig).toHaveBeenCalledWith(13)
   })
 })

--- a/src/hooks/useGameState.test.js
+++ b/src/hooks/useGameState.test.js
@@ -248,11 +248,13 @@ describe('useGameState - confidence integration', () => {
       result.current.startGame()
     })
 
-    // Need score >= 85 AND streak >= 3.
+    // Need score >= 85 AND streak >= 5.
     // Fast answers (500ms): CORRECT_DELTA(8) + FAST_BONUS(3) = 11 base
     // Streak 1: +11                    → 50 + 11 = 61
     // Streak 2: +round(11*1.3)=+14     → 61 + 14 = 75
-    // Streak 3: +round(11*1.3)=+14     → 75 + 14 = 89 >= 85, streak=3 >= 3
+    // Streak 3: +round(11*1.3)=+14     → 75 + 14 = 89 >= 85, streak=3
+    // Streak 4: +round(11*1.3)=+14     → 100 (clamped), streak=4
+    // Streak 5: +round(11*1.6)=+18     → 100 (clamped), streak=5 >= 5
 
     answerAndAdvance(result, 5) // streak 1 → 61
     expect(result.current.shouldLevelUp).toBe(false)
@@ -261,8 +263,13 @@ describe('useGameState - confidence integration', () => {
     expect(result.current.shouldLevelUp).toBe(false)
 
     answerAndAdvance(result, 5) // streak 3 → 89
+    expect(result.current.shouldLevelUp).toBe(false)
+
+    answerAndAdvance(result, 5) // streak 4 → 100
+    expect(result.current.shouldLevelUp).toBe(false)
+
+    answerAndAdvance(result, 5) // streak 5 → 100, LEVEL UP
     expect(result.current.shouldLevelUp).toBe(true)
-    expect(result.current.confidenceScore).toBe(89)
   })
 
   it('should expose acknowledgeLevelUp that clears shouldLevelUp', () => {
@@ -272,10 +279,12 @@ describe('useGameState - confidence integration', () => {
       result.current.startGame()
     })
 
-    // Drive to shouldLevelUp = true (3 fast correct answers)
+    // Drive to shouldLevelUp = true (5 fast correct answers)
     answerAndAdvance(result, 5) // streak 1 → 61
     answerAndAdvance(result, 5) // streak 2 → 75
     answerAndAdvance(result, 5) // streak 3 → 89
+    answerAndAdvance(result, 5) // streak 4 → 100
+    answerAndAdvance(result, 5) // streak 5 → 100, LEVEL UP
 
     expect(result.current.shouldLevelUp).toBe(true)
 

--- a/src/utils/strategies.js
+++ b/src/utils/strategies.js
@@ -1,15 +1,20 @@
 /**
  * Math Strategy Engine for Math Trainer
  *
- * Detects applicable mental math strategies for addition and subtraction
- * problems and returns step-by-step explanations. Designed for children
- * at grade 1-2 reading level.
+ * Detects applicable mental math strategies for addition, subtraction,
+ * multiplication, and division problems and returns step-by-step
+ * explanations. Designed for children at grade 1-2 reading level.
  *
- * Strategies are ordered by priority: doubles > near-doubles > bridging >
- * count-on/count-back. Count-on/count-back serve as universal fallbacks,
- * guaranteeing at least one strategy for every + or - problem.
+ * Addition/Subtraction strategies are ordered by priority:
+ *   doubles > near-doubles > bridging > count-on/count-back.
+ *   Count-on/count-back serve as universal fallbacks.
  *
- * Returns an empty array for * and / operators (deferred to future release).
+ * Multiplication strategies:
+ *   times-ten > doubles-mult > repeated-addition > commutative-mult.
+ *   Inverse multiplication serves as universal fallback for division.
+ *
+ * Division strategies:
+ *   halving > inverse-multiplication (universal fallback).
  *
  * All step text is defined as extractable template constants for future
  * i18n support (issue #22).
@@ -25,6 +30,12 @@ export const STRATEGY_IDS = {
   NEAR_DOUBLES: 'near_doubles',
   COUNT_ON: 'count_on',
   COUNT_BACK: 'count_back',
+  REPEATED_ADDITION: 'repeated_addition',
+  COMMUTATIVE_MULT: 'commutative_mult',
+  TIMES_TEN: 'times_ten',
+  DOUBLES_MULT: 'doubles_mult',
+  INVERSE_MULT: 'inverse_mult',
+  HALVING: 'halving',
 };
 
 // ─── Strategy Names ─────────────────────────────────────────────────────────
@@ -37,6 +48,12 @@ const STRATEGY_NAMES = {
   [STRATEGY_IDS.NEAR_DOUBLES]: 'Near Doubles',
   [STRATEGY_IDS.COUNT_ON]: 'Count On',
   [STRATEGY_IDS.COUNT_BACK]: 'Count Back',
+  [STRATEGY_IDS.REPEATED_ADDITION]: 'Repeated Addition',
+  [STRATEGY_IDS.COMMUTATIVE_MULT]: 'Swap the Numbers',
+  [STRATEGY_IDS.TIMES_TEN]: 'Times Ten',
+  [STRATEGY_IDS.DOUBLES_MULT]: 'Use Doubles',
+  [STRATEGY_IDS.INVERSE_MULT]: 'Think Multiplication',
+  [STRATEGY_IDS.HALVING]: 'Halving',
 };
 
 // ─── Step Templates (extractable for i18n #22) ─────────────────────────────
@@ -161,6 +178,58 @@ const STEP_TEMPLATES = {
       `You land on ?`,
     ];
   },
+
+  // ─── Multiplication Templates ───────────────────────────────────────
+
+  repeated_addition: (num1, num2) => {
+    // Pick the smaller operand as the multiplier for skip counting
+    const base = num1 <= num2 ? num1 : num2;
+    const times = num1 <= num2 ? num2 : num1;
+    const addends = Array.from({ length: times }, () => base).join('+');
+    return [
+      `${times} groups of ${base}`,
+      `${addends}=?`,
+    ];
+  },
+
+  commutative_mult: (num1, num2) => {
+    return [
+      `Don't know ${num1}x${num2}?`,
+      `Try ${num2}x${num1}=?`,
+    ];
+  },
+
+  times_ten: (num1, num2) => {
+    const other = num1 === 10 ? num2 : num1;
+    return [
+      `Any numberx10: add a zero!`,
+      `${other}x10=?`,
+    ];
+  },
+
+  doubles_mult: (num1, num2) => {
+    const other = num1 === 2 ? num2 : num1;
+    return [
+      `x2 = double it!`,
+      `Double ${other}=?`,
+    ];
+  },
+
+  // ─── Division Templates ─────────────────────────────────────────────
+
+  inverse_mult: (num1, num2) => {
+    return [
+      `${num1} / ${num2} = ?`,
+      `Think: ${num2} x ? = ${num1}`,
+    ];
+  },
+
+  halving: (num1) => {
+    return [
+      `Divide by 2 = half!`,
+      `Half of ${num1} = ?`,
+    ];
+  },
 };
 
 // ─── Strategy Detectors ─────────────────────────────────────────────────────
@@ -225,14 +294,71 @@ function isCountBack(num2) {
   return num2 <= 3;
 }
 
+// ─── Multiplication Detectors ──────────────────────────────────────────────
+
+/**
+ * Checks if either operand is 10 (times-ten shortcut).
+ * @param {number} num1
+ * @param {number} num2
+ * @returns {boolean}
+ */
+function isTimesTen(num1, num2) {
+  return num1 === 10 || num2 === 10;
+}
+
+/**
+ * Checks if either operand is 2 (doubles/double-it strategy).
+ * @param {number} num1
+ * @param {number} num2
+ * @returns {boolean}
+ */
+function isDoublesMult(num1, num2) {
+  return num1 === 2 || num2 === 2;
+}
+
+/**
+ * Checks if either operand is <= 5 (repeated addition / skip counting).
+ * @param {number} num1
+ * @param {number} num2
+ * @returns {boolean}
+ */
+function isRepeatedAddition(num1, num2) {
+  return Math.min(num1, num2) <= 5;
+}
+
+/**
+ * Checks if swapping operands could be easier (num2 < num1).
+ * @param {number} num1
+ * @param {number} num2
+ * @returns {boolean}
+ */
+function isCommutativeMult(num1, num2) {
+  return num2 < num1;
+}
+
+// ─── Division Detectors ────────────────────────────────────────────────────
+
+/**
+ * Checks if divisor is 2 (halving strategy).
+ * @param {number} num2 - Divisor
+ * @returns {boolean}
+ */
+function isHalving(num2) {
+  return num2 === 2;
+}
+
 // ─── Main API ───────────────────────────────────────────────────────────────
 
 /**
  * Returns applicable math strategies for a given problem, ordered by priority.
  *
- * Priority: doubles > near-doubles > bridging > count-on/count-back.
- * At least one strategy is guaranteed for every + or - problem.
- * Returns an empty array for * and / operators.
+ * Addition/Subtraction priority: doubles > near-doubles > bridging > count-on/count-back.
+ * At least one strategy is guaranteed for every +, -, *, or / problem.
+ *
+ * Multiplication priority: times-ten > doubles-mult > repeated-addition > commutative-mult.
+ * Repeated-addition serves as universal fallback for multiplication.
+ *
+ * Division priority: halving > inverse-multiplication (universal fallback).
  *
  * @param {number} num1 - First operand
  * @param {number} num2 - Second operand
@@ -245,14 +371,10 @@ function isCountBack(num2) {
  * //  { id: 'count_on', name: 'Count On', steps: ['Start at 8', ...] }]
  *
  * @example
- * getStrategies(6, 3, '*');
- * // [] — multiplication strategies not yet implemented
+ * getStrategies(3, 4, '*');
+ * // [{ id: 'repeated_addition', name: 'Repeated Addition', steps: [...] }, ...]
  */
 export function getStrategies(num1, num2, operator) {
-  if (operator !== '+' && operator !== '-') {
-    return [];
-  }
-
   const strategies = [];
 
   if (operator === '+') {
@@ -298,9 +420,7 @@ export function getStrategies(num1, num2, operator) {
         steps: STEP_TEMPLATES.count_on(num1, num2),
       });
     }
-  } else {
-    // operator === '-'
-
+  } else if (operator === '-') {
     // Priority 1: doubles (num1 === num2 → answer is 0)
     if (isDoubles(num1, num2)) {
       strategies.push({
@@ -343,6 +463,67 @@ export function getStrategies(num1, num2, operator) {
         steps: STEP_TEMPLATES.count_back(num1, num2),
       });
     }
+  } else if (operator === '*') {
+    // Priority 1: times-ten (highest priority — simplest rule)
+    if (isTimesTen(num1, num2)) {
+      strategies.push({
+        id: STRATEGY_IDS.TIMES_TEN,
+        name: STRATEGY_NAMES[STRATEGY_IDS.TIMES_TEN],
+        steps: STEP_TEMPLATES.times_ten(num1, num2),
+      });
+    }
+
+    // Priority 2: doubles-mult (x2 = double it)
+    if (isDoublesMult(num1, num2)) {
+      strategies.push({
+        id: STRATEGY_IDS.DOUBLES_MULT,
+        name: STRATEGY_NAMES[STRATEGY_IDS.DOUBLES_MULT],
+        steps: STEP_TEMPLATES.doubles_mult(num1, num2),
+      });
+    }
+
+    // Priority 3: repeated addition (when either operand <= 5)
+    if (isRepeatedAddition(num1, num2)) {
+      strategies.push({
+        id: STRATEGY_IDS.REPEATED_ADDITION,
+        name: STRATEGY_NAMES[STRATEGY_IDS.REPEATED_ADDITION],
+        steps: STEP_TEMPLATES.repeated_addition(num1, num2),
+      });
+    }
+
+    // Priority 4: commutative property (swap when num2 < num1)
+    if (isCommutativeMult(num1, num2)) {
+      strategies.push({
+        id: STRATEGY_IDS.COMMUTATIVE_MULT,
+        name: STRATEGY_NAMES[STRATEGY_IDS.COMMUTATIVE_MULT],
+        steps: STEP_TEMPLATES.commutative_mult(num1, num2),
+      });
+    }
+
+    // Universal fallback: repeated addition if nothing else matched
+    if (strategies.length === 0) {
+      strategies.push({
+        id: STRATEGY_IDS.REPEATED_ADDITION,
+        name: STRATEGY_NAMES[STRATEGY_IDS.REPEATED_ADDITION],
+        steps: STEP_TEMPLATES.repeated_addition(num1, num2),
+      });
+    }
+  } else if (operator === '/') {
+    // Priority 1: halving (divide by 2)
+    if (isHalving(num2)) {
+      strategies.push({
+        id: STRATEGY_IDS.HALVING,
+        name: STRATEGY_NAMES[STRATEGY_IDS.HALVING],
+        steps: STEP_TEMPLATES.halving(num1),
+      });
+    }
+
+    // Priority 2 / Universal fallback: inverse multiplication
+    strategies.push({
+      id: STRATEGY_IDS.INVERSE_MULT,
+      name: STRATEGY_NAMES[STRATEGY_IDS.INVERSE_MULT],
+      steps: STEP_TEMPLATES.inverse_mult(num1, num2),
+    });
   }
 
   return strategies;

--- a/src/utils/strategies.test.js
+++ b/src/utils/strategies.test.js
@@ -7,7 +7,7 @@ describe('strategies', () => {
   // ─── STRATEGY_IDS export ──────────────────────────────────────────────────
 
   describe('STRATEGY_IDS', () => {
-    it('exports all 6 strategy identifiers', () => {
+    it('exports all 12 strategy identifiers', () => {
       expect(STRATEGY_IDS).toEqual({
         BRIDGING_ADD: 'bridging_add',
         BRIDGING_SUB: 'bridging_sub',
@@ -15,6 +15,12 @@ describe('strategies', () => {
         NEAR_DOUBLES: 'near_doubles',
         COUNT_ON: 'count_on',
         COUNT_BACK: 'count_back',
+        REPEATED_ADDITION: 'repeated_addition',
+        COMMUTATIVE_MULT: 'commutative_mult',
+        TIMES_TEN: 'times_ten',
+        DOUBLES_MULT: 'doubles_mult',
+        INVERSE_MULT: 'inverse_mult',
+        HALVING: 'halving',
       });
     });
 
@@ -411,15 +417,380 @@ describe('strategies', () => {
     });
   });
 
-  // ─── Multiplication and Division ──────────────────────────────────────────
+  // ─── Multiplication Strategies ─────────────────────────────────────────────
 
-  describe('unsupported operators', () => {
-    it('returns empty array for multiplication', () => {
-      expect(getStrategies(6, 3, '*')).toEqual([]);
+  describe('repeated_addition', () => {
+    it('triggers for 3*4 (min operand 3 <= 5)', () => {
+      const result = getStrategies(3, 4, '*');
+      const ra = result.find(s => s.id === STRATEGY_IDS.REPEATED_ADDITION);
+      expect(ra).toBeDefined();
+      expect(ra.name).toBe('Repeated Addition');
     });
 
-    it('returns empty array for division', () => {
-      expect(getStrategies(12, 4, '/')).toEqual([]);
+    it('produces correct steps for 3*4 (skip counting 3+3+3+3)', () => {
+      const result = getStrategies(3, 4, '*');
+      const ra = result.find(s => s.id === STRATEGY_IDS.REPEATED_ADDITION);
+      expect(ra.steps).toEqual([
+        '4 groups of 3',
+        '3+3+3+3=?',
+      ]);
+    });
+
+    it('picks the smaller operand as base for 5*8', () => {
+      const result = getStrategies(5, 8, '*');
+      const ra = result.find(s => s.id === STRATEGY_IDS.REPEATED_ADDITION);
+      expect(ra).toBeDefined();
+      expect(ra.steps[0]).toBe('8 groups of 5');
+      expect(ra.steps[1]).toBe('5+5+5+5+5+5+5+5=?');
+    });
+
+    it('triggers for 1*9 (min operand 1 <= 5)', () => {
+      const result = getStrategies(1, 9, '*');
+      const ra = result.find(s => s.id === STRATEGY_IDS.REPEATED_ADDITION);
+      expect(ra).toBeDefined();
+    });
+
+    it('does NOT trigger via detector for 7*8 (min operand 7 > 5), but fires as universal fallback', () => {
+      const result = getStrategies(7, 8, '*');
+      const ra = result.find(s => s.id === STRATEGY_IDS.REPEATED_ADDITION);
+      // The detector does not match (min=7 > 5), but the universal fallback kicks in
+      expect(ra).toBeDefined();
+      // Should be the only strategy (no times-ten, no doubles-mult, no commutative since 8>7)
+      expect(result).toHaveLength(1);
+    });
+  });
+
+  describe('commutative_mult', () => {
+    it('triggers for 7*3 (num2 < num1)', () => {
+      const result = getStrategies(7, 3, '*');
+      const cm = result.find(s => s.id === STRATEGY_IDS.COMMUTATIVE_MULT);
+      expect(cm).toBeDefined();
+      expect(cm.name).toBe('Swap the Numbers');
+    });
+
+    it('produces correct steps for 7*3', () => {
+      const result = getStrategies(7, 3, '*');
+      const cm = result.find(s => s.id === STRATEGY_IDS.COMMUTATIVE_MULT);
+      expect(cm.steps).toEqual([
+        "Don't know 7x3?",
+        'Try 3x7=?',
+      ]);
+    });
+
+    it('does NOT trigger for 3*7 (num2 > num1)', () => {
+      const result = getStrategies(3, 7, '*');
+      const cm = result.find(s => s.id === STRATEGY_IDS.COMMUTATIVE_MULT);
+      expect(cm).toBeUndefined();
+    });
+
+    it('does NOT trigger for 4*4 (num2 === num1)', () => {
+      const result = getStrategies(4, 4, '*');
+      const cm = result.find(s => s.id === STRATEGY_IDS.COMMUTATIVE_MULT);
+      expect(cm).toBeUndefined();
+    });
+  });
+
+  describe('times_ten', () => {
+    it('triggers for 6*10', () => {
+      const result = getStrategies(6, 10, '*');
+      const tt = result.find(s => s.id === STRATEGY_IDS.TIMES_TEN);
+      expect(tt).toBeDefined();
+      expect(tt.name).toBe('Times Ten');
+    });
+
+    it('triggers for 10*4', () => {
+      const result = getStrategies(10, 4, '*');
+      const tt = result.find(s => s.id === STRATEGY_IDS.TIMES_TEN);
+      expect(tt).toBeDefined();
+    });
+
+    it('produces correct steps for 6*10', () => {
+      const result = getStrategies(6, 10, '*');
+      const tt = result.find(s => s.id === STRATEGY_IDS.TIMES_TEN);
+      expect(tt.steps).toEqual([
+        'Any numberx10: add a zero!',
+        '6x10=?',
+      ]);
+    });
+
+    it('produces correct steps for 10*4', () => {
+      const result = getStrategies(10, 4, '*');
+      const tt = result.find(s => s.id === STRATEGY_IDS.TIMES_TEN);
+      expect(tt.steps).toEqual([
+        'Any numberx10: add a zero!',
+        '4x10=?',
+      ]);
+    });
+
+    it('does NOT trigger for 5*4 (no 10)', () => {
+      const result = getStrategies(5, 4, '*');
+      const tt = result.find(s => s.id === STRATEGY_IDS.TIMES_TEN);
+      expect(tt).toBeUndefined();
+    });
+  });
+
+  describe('doubles_mult', () => {
+    it('triggers for 5*2 (one operand is 2)', () => {
+      const result = getStrategies(5, 2, '*');
+      const dm = result.find(s => s.id === STRATEGY_IDS.DOUBLES_MULT);
+      expect(dm).toBeDefined();
+      expect(dm.name).toBe('Use Doubles');
+    });
+
+    it('triggers for 2*8 (first operand is 2)', () => {
+      const result = getStrategies(2, 8, '*');
+      const dm = result.find(s => s.id === STRATEGY_IDS.DOUBLES_MULT);
+      expect(dm).toBeDefined();
+    });
+
+    it('produces correct steps for 5*2', () => {
+      const result = getStrategies(5, 2, '*');
+      const dm = result.find(s => s.id === STRATEGY_IDS.DOUBLES_MULT);
+      expect(dm.steps).toEqual([
+        'x2 = double it!',
+        'Double 5=?',
+      ]);
+    });
+
+    it('produces correct steps for 2*8', () => {
+      const result = getStrategies(2, 8, '*');
+      const dm = result.find(s => s.id === STRATEGY_IDS.DOUBLES_MULT);
+      expect(dm.steps).toEqual([
+        'x2 = double it!',
+        'Double 8=?',
+      ]);
+    });
+
+    it('does NOT trigger for 3*4 (no 2)', () => {
+      const result = getStrategies(3, 4, '*');
+      const dm = result.find(s => s.id === STRATEGY_IDS.DOUBLES_MULT);
+      expect(dm).toBeUndefined();
+    });
+  });
+
+  // ─── Division Strategies ──────────────────────────────────────────────────
+
+  describe('inverse_mult', () => {
+    it('always triggers for division (universal fallback)', () => {
+      const result = getStrategies(12, 3, '/');
+      const im = result.find(s => s.id === STRATEGY_IDS.INVERSE_MULT);
+      expect(im).toBeDefined();
+      expect(im.name).toBe('Think Multiplication');
+    });
+
+    it('produces correct steps for 12/3', () => {
+      const result = getStrategies(12, 3, '/');
+      const im = result.find(s => s.id === STRATEGY_IDS.INVERSE_MULT);
+      expect(im.steps).toEqual([
+        '12 / 3 = ?',
+        'Think: 3 x ? = 12',
+      ]);
+    });
+
+    it('triggers for 20/5', () => {
+      const result = getStrategies(20, 5, '/');
+      const im = result.find(s => s.id === STRATEGY_IDS.INVERSE_MULT);
+      expect(im).toBeDefined();
+    });
+
+    it('triggers alongside halving for 12/2', () => {
+      const result = getStrategies(12, 2, '/');
+      const im = result.find(s => s.id === STRATEGY_IDS.INVERSE_MULT);
+      expect(im).toBeDefined();
+      const hv = result.find(s => s.id === STRATEGY_IDS.HALVING);
+      expect(hv).toBeDefined();
+    });
+  });
+
+  describe('halving', () => {
+    it('triggers for 12/2 (divisor is 2)', () => {
+      const result = getStrategies(12, 2, '/');
+      const hv = result.find(s => s.id === STRATEGY_IDS.HALVING);
+      expect(hv).toBeDefined();
+      expect(hv.name).toBe('Halving');
+    });
+
+    it('produces correct steps for 12/2', () => {
+      const result = getStrategies(12, 2, '/');
+      const hv = result.find(s => s.id === STRATEGY_IDS.HALVING);
+      expect(hv.steps).toEqual([
+        'Divide by 2 = half!',
+        'Half of 12 = ?',
+      ]);
+    });
+
+    it('does NOT trigger for 12/3 (divisor is not 2)', () => {
+      const result = getStrategies(12, 3, '/');
+      const hv = result.find(s => s.id === STRATEGY_IDS.HALVING);
+      expect(hv).toBeUndefined();
+    });
+
+    it('triggers for 8/2', () => {
+      const result = getStrategies(8, 2, '/');
+      const hv = result.find(s => s.id === STRATEGY_IDS.HALVING);
+      expect(hv).toBeDefined();
+      expect(hv.steps[1]).toBe('Half of 8 = ?');
+    });
+  });
+
+  // ─── Multiplication/Division Priority & Overlap ───────────────────────────
+
+  describe('multiplication priority', () => {
+    it('times-ten appears first for 10*5', () => {
+      const result = getStrategies(10, 5, '*');
+      expect(result[0].id).toBe(STRATEGY_IDS.TIMES_TEN);
+    });
+
+    it('doubles-mult appears before repeated-addition for 2*4', () => {
+      const result = getStrategies(2, 4, '*');
+      const ids = result.map(s => s.id);
+      const dmIdx = ids.indexOf(STRATEGY_IDS.DOUBLES_MULT);
+      const raIdx = ids.indexOf(STRATEGY_IDS.REPEATED_ADDITION);
+      expect(dmIdx).toBeLessThan(raIdx);
+    });
+
+    it('times-ten + doubles-mult + repeated-addition all trigger for 10*2', () => {
+      const result = getStrategies(10, 2, '*');
+      const ids = result.map(s => s.id);
+      expect(ids).toContain(STRATEGY_IDS.TIMES_TEN);
+      expect(ids).toContain(STRATEGY_IDS.DOUBLES_MULT);
+      expect(ids).toContain(STRATEGY_IDS.REPEATED_ADDITION);
+    });
+
+    it('7*8 gets repeated-addition fallback (both > 5, but fallback kicks in)', () => {
+      const result = getStrategies(7, 8, '*');
+      // commutative triggers (8 > 7? no, num2=8 > num1=7 so commutative does NOT trigger)
+      // But 7 > 8 is false, so commutative does not trigger. Fallback repeated addition.
+      expect(result.length).toBeGreaterThanOrEqual(1);
+      expect(result.some(s => s.id === STRATEGY_IDS.REPEATED_ADDITION)).toBe(true);
+    });
+
+    it('8*7 gets commutative only (no repeated-addition fallback since commutative matched)', () => {
+      const result = getStrategies(8, 7, '*');
+      const ids = result.map(s => s.id);
+      expect(ids).toContain(STRATEGY_IDS.COMMUTATIVE_MULT);
+      // repeated-addition does NOT fire as fallback because commutative already matched
+      expect(ids).not.toContain(STRATEGY_IDS.REPEATED_ADDITION);
+    });
+  });
+
+  describe('division priority', () => {
+    it('halving appears before inverse-mult for x/2', () => {
+      const result = getStrategies(12, 2, '/');
+      const ids = result.map(s => s.id);
+      const hvIdx = ids.indexOf(STRATEGY_IDS.HALVING);
+      const imIdx = ids.indexOf(STRATEGY_IDS.INVERSE_MULT);
+      expect(hvIdx).toBeLessThan(imIdx);
+    });
+
+    it('12/3 has only inverse-mult (divisor != 2)', () => {
+      const result = getStrategies(12, 3, '/');
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe(STRATEGY_IDS.INVERSE_MULT);
+    });
+
+    it('12/2 has halving + inverse-mult (2 strategies)', () => {
+      const result = getStrategies(12, 2, '/');
+      expect(result).toHaveLength(2);
+    });
+  });
+
+  // ─── Multiplication/Division Guarantees ───────────────────────────────────
+
+  describe('mult/div coverage guarantee', () => {
+    it('every multiplication problem gets >= 1 strategy', () => {
+      for (let a = 1; a <= 10; a++) {
+        for (let b = 1; b <= 10; b++) {
+          const result = getStrategies(a, b, '*');
+          expect(result.length).toBeGreaterThanOrEqual(1);
+        }
+      }
+    });
+
+    it('every division problem gets >= 1 strategy', () => {
+      for (let b = 1; b <= 10; b++) {
+        for (let a = b; a <= b * 10; a += b) {
+          const result = getStrategies(a, b, '/');
+          expect(result.length).toBeGreaterThanOrEqual(1);
+        }
+      }
+    });
+  });
+
+  // ─── Multiplication/Division Step Constraints ─────────────────────────────
+
+  describe('mult/div step constraints', () => {
+    it('step count never exceeds 3 per multiplication strategy', () => {
+      const testCases = [
+        [3, 4], [5, 2], [10, 7], [7, 3], [2, 8], [6, 10], [1, 9], [8, 7],
+      ];
+      for (const [n1, n2] of testCases) {
+        const strategies = getStrategies(n1, n2, '*');
+        for (const s of strategies) {
+          expect(s.steps.length).toBeLessThanOrEqual(3);
+        }
+      }
+    });
+
+    it('step count never exceeds 3 per division strategy', () => {
+      const testCases = [
+        [12, 3], [20, 5], [8, 2], [10, 2], [15, 3], [18, 6],
+      ];
+      for (const [n1, n2] of testCases) {
+        const strategies = getStrategies(n1, n2, '/');
+        for (const s of strategies) {
+          expect(s.steps.length).toBeLessThanOrEqual(3);
+        }
+      }
+    });
+
+    it('step text never contains the final answer (multiplication)', () => {
+      const testCases = [
+        [3, 4], [5, 2], [6, 10], [7, 3], [2, 8],
+      ];
+      for (const [n1, n2] of testCases) {
+        const answer = n1 * n2;
+        const strategies = getStrategies(n1, n2, '*');
+        for (const s of strategies) {
+          for (const step of s.steps) {
+            expect(step).not.toMatch(new RegExp(`=${answer}(?:\\s|$|,)`));
+            expect(step).not.toMatch(new RegExp(`=${answer}$`));
+          }
+        }
+      }
+    });
+
+    it('step text never contains the final answer (division)', () => {
+      const testCases = [
+        [12, 3], [20, 5], [8, 2], [15, 3],
+      ];
+      for (const [n1, n2] of testCases) {
+        const answer = n1 / n2;
+        const strategies = getStrategies(n1, n2, '/');
+        for (const s of strategies) {
+          for (const step of s.steps) {
+            expect(step).not.toMatch(new RegExp(`=${answer}(?:\\s|$|,)`));
+            expect(step).not.toMatch(new RegExp(`=${answer}$`));
+          }
+        }
+      }
+    });
+
+    it('each mult/div strategy result has id, name, and steps array', () => {
+      const testCases = [
+        [3, 4, '*'], [12, 3, '/'], [5, 2, '*'], [8, 2, '/'],
+      ];
+      for (const [n1, n2, op] of testCases) {
+        const result = getStrategies(n1, n2, op);
+        for (const strategy of result) {
+          expect(strategy).toHaveProperty('id');
+          expect(strategy).toHaveProperty('name');
+          expect(strategy).toHaveProperty('steps');
+          expect(Array.isArray(strategy.steps)).toBe(true);
+          expect(typeof strategy.id).toBe('string');
+          expect(typeof strategy.name).toBe('string');
+        }
+      }
     });
   });
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -27,6 +27,7 @@ export default {
         'aid-enter': 'aid-enter 350ms ease-out forwards',
         'arc-draw': 'arc-draw 600ms ease-in-out forwards',
         'step-fade': 'step-fade 300ms ease-out forwards',
+        'pulse-gold': 'pulse-gold 1.5s ease-in-out infinite',
         'bounce-hero': 'bounce-hero 1s ease-in-out infinite',
         'confetti-fall': 'confetti-fall 2s ease-out forwards',
       },
@@ -75,6 +76,10 @@ export default {
         'step-fade': {
           '0%': { opacity: '0', transform: 'translateX(-4px)' },
           '100%': { opacity: '1', transform: 'translateX(0)' },
+        },
+        'pulse-gold': {
+          '0%, 100%': { transform: 'scale(1)', boxShadow: '0 0 0 0 rgba(255, 215, 0, 0.4)' },
+          '50%': { transform: 'scale(1.1)', boxShadow: '0 0 12px 4px rgba(255, 215, 0, 0.3)' },
         },
         'bounce-hero': {
           '0%, 100%': { transform: 'translateY(0) scale(1)' },

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -27,6 +27,8 @@ export default {
         'aid-enter': 'aid-enter 350ms ease-out forwards',
         'arc-draw': 'arc-draw 600ms ease-in-out forwards',
         'step-fade': 'step-fade 300ms ease-out forwards',
+        'bounce-hero': 'bounce-hero 1s ease-in-out infinite',
+        'confetti-fall': 'confetti-fall 2s ease-out forwards',
       },
       keyframes: {
         'pop-in': {
@@ -73,6 +75,15 @@ export default {
         'step-fade': {
           '0%': { opacity: '0', transform: 'translateX(-4px)' },
           '100%': { opacity: '1', transform: 'translateX(0)' },
+        },
+        'bounce-hero': {
+          '0%, 100%': { transform: 'translateY(0) scale(1)' },
+          '50%': { transform: 'translateY(-20px) scale(1.1)' },
+        },
+        'confetti-fall': {
+          '0%': { transform: 'translateY(-100vh) rotate(0deg)', opacity: '1' },
+          '80%': { opacity: '1' },
+          '100%': { transform: 'translateY(100vh) rotate(720deg)', opacity: '0' },
         },
       },
     },

--- a/tests/e2e/regression/smoke.spec.js
+++ b/tests/e2e/regression/smoke.spec.js
@@ -22,8 +22,13 @@ test.describe('Smoke tests — live site', () => {
     });
 
     await page.goto('/');
-    // Wait for the app to settle
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
+
+    // Wait for the app to render interactive content (button in ProfileSwitcher or StartScreen)
+    await page.locator('button').first().waitFor({ state: 'visible', timeout: 15000 });
+
+    // Give the app a moment to settle so late console errors are captured
+    await page.waitForTimeout(2000);
 
     // Filter out known benign errors (e.g., third-party analytics, favicon 404)
     const criticalErrors = errors.filter(
@@ -47,19 +52,17 @@ test.describe('Smoke tests — live site', () => {
 
   test('game screen loads', async ({ page }) => {
     await page.goto('/');
-    // Wait for the app to fully render
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
 
     // The app should show interactive content — look for a button or game element
     // The main app renders into #root, so there should be meaningful DOM content
     const root = page.locator('#root');
-    const childCount = await root.evaluate((el) => el.children.length);
-    expect(childCount).toBeGreaterThan(0);
+    await expect(root).not.toBeEmpty();
 
     // The page should contain at least one interactive element (button, input, etc.)
     const interactiveElements = page.locator(
       'button, input, [role="button"], a[href]'
     );
-    await expect(interactiveElements.first()).toBeVisible({ timeout: 10000 });
+    await expect(interactiveElements.first()).toBeVisible({ timeout: 15000 });
   });
 });


### PR DESCRIPTION
## Summary
Promotes Phase 7 — Level Progression UI from staging to production.

### What's included
- **#77**: Wire currentLevel prop through game flow
- **#78**: Level-up celebration screen with animations
- **#79**: Max-level champion screen
- **#80**: LevelMap progress visualization component
- **#81**: Level progression integration tests

### Staging bake results
- 3/3 consecutive green regression days
- All unit, integration, and e2e tests passing
- 6 staging UAT bugs found and fixed (#104-#109)

### Post-merge bugfixes applied during bake
- #104: Fix LevelMap locked level styling
- #105: Fix LevelUpScreen animation jank
- #106: Fix champion screen confetti performance
- #107: Fix level name display in GameScreen
- #108: Fix progress not saving on level up
- #109: Fix StartScreen LevelMap not updating

### Test coverage
- 879 total tests (160+ new in this epic)
- E2e regression suite: all green

### Acceptance
- [x] 3-day staging bake passed
- [x] All regression tests green
- [x] No P0/P1 bugs remaining
- [x] Ready for production