### PR TITLE
feat: add ErrorBoundary with child-friendly fallback (#124)

### DIFF
--- a/src/components/ErrorBoundary.jsx
+++ b/src/components/ErrorBoundary.jsx
@@ -1,0 +1,111 @@
+import React from 'react'
+
+/**
+ * ErrorBoundary — Root-level error catcher for Math Trainer
+ *
+ * Intentionally uses NO i18n, context providers, or Firebase.
+ * This component sits ABOVE all providers so it must be self-contained.
+ * Error details (message, stack, componentStack) are intentionally
+ * withheld from the UI to prevent information leakage.
+ *
+ * Bilingual fallback UI (Hebrew + English) is hardcoded here
+ * since the i18n provider may itself be the source of the error.
+ */
+class ErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props)
+    this.state = { hasError: false, error: null }
+    this.handleReset = this.handleReset.bind(this)
+  }
+
+  static getDerivedStateFromError(error) {
+    return { hasError: true, error }
+  }
+
+  componentDidCatch(error, info) {
+    // Sentry-ready: replace with Sentry.captureException(error, { extra: info })
+    console.error('ErrorBoundary caught:', error, info)
+  }
+
+  handleReset() {
+    this.setState({ hasError: false, error: null })
+  }
+
+  render() {
+    if (!this.state.hasError) {
+      return this.props.children
+    }
+
+    return (
+      <div
+        role="alert"
+        style={{
+          minHeight: '100vh',
+          background: 'linear-gradient(to bottom, #0066cc, #003d7a)',
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          padding: '2rem',
+          fontFamily: 'sans-serif',
+          textAlign: 'center',
+          color: '#ffffff',
+        }}
+      >
+        <div
+          style={{ fontSize: '4rem', marginBottom: '1rem' }}
+          role="img"
+          aria-label="hedgehog"
+        >
+          &#x1F994;
+        </div>
+
+        <h1
+          style={{
+            fontSize: '1.75rem',
+            fontWeight: 'bold',
+            marginBottom: '0.5rem',
+            lineHeight: 1.3,
+          }}
+          dir="rtl"
+        >
+          אופס! משהו קרה...
+        </h1>
+
+        <p
+          style={{
+            fontSize: '1.25rem',
+            marginBottom: '2rem',
+            opacity: 0.85,
+          }}
+          lang="en"
+        >
+          Oops! Something happened...
+        </p>
+
+        <button
+          onClick={this.handleReset}
+          style={{
+            background: 'linear-gradient(to right, #ffd700, #ffc107)',
+            color: '#003d7a',
+            fontWeight: 'bold',
+            fontSize: '1.25rem',
+            padding: '0.875rem 2.5rem',
+            borderRadius: '1rem',
+            border: 'none',
+            cursor: 'pointer',
+            minHeight: '44px',
+            boxShadow: '0 4px 12px rgba(255, 215, 0, 0.4)',
+          }}
+          aria-label="Try again"
+        >
+          <span dir="rtl">בוא ננסה שוב</span>
+          {' / '}
+          <span lang="en">Let&#x27;s try again</span>
+        </button>
+      </div>
+    )
+  }
+}
+
+export default ErrorBoundary

--- a/src/components/ErrorBoundary.test.jsx
+++ b/src/components/ErrorBoundary.test.jsx
@@ -1,0 +1,235 @@
+/**
+ * @vitest-environment happy-dom
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+import React from 'react'
+import ErrorBoundary from './ErrorBoundary'
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/**
+ * A component that throws on render when `shouldThrow` prop is true.
+ * The thrown error intentionally contains sensitive strings to verify
+ * they never reach the rendered output.
+ */
+function BrokenChild({ shouldThrow = false }) {
+  if (shouldThrow) {
+    throw new Error('secret-error-message: db connection string xyz')
+  }
+  return <div data-testid="healthy-child">All good</div>
+}
+
+/**
+ * Suppress the expected console.error output so test output stays clean.
+ * React also prints its own error overlay logs for uncaught errors in tests.
+ */
+let consoleErrorSpy
+
+beforeEach(() => {
+  consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+})
+
+afterEach(() => {
+  consoleErrorSpy.mockRestore()
+  cleanup()
+})
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('ErrorBoundary', () => {
+  describe('normal rendering (no error)', () => {
+    it('renders children when no error is thrown', () => {
+      render(
+        <ErrorBoundary>
+          <BrokenChild shouldThrow={false} />
+        </ErrorBoundary>,
+      )
+      expect(screen.getByTestId('healthy-child')).toBeTruthy()
+    })
+
+    it('does not show the fallback UI when children render normally', () => {
+      render(
+        <ErrorBoundary>
+          <BrokenChild shouldThrow={false} />
+        </ErrorBoundary>,
+      )
+      expect(screen.queryByRole('alert')).toBeNull()
+    })
+  })
+
+  describe('fallback UI (error state)', () => {
+    it('catches a render error and shows the fallback', () => {
+      render(
+        <ErrorBoundary>
+          <BrokenChild shouldThrow={true} />
+        </ErrorBoundary>,
+      )
+      expect(screen.getByRole('alert')).toBeTruthy()
+    })
+
+    it('shows the Hebrew error message', () => {
+      render(
+        <ErrorBoundary>
+          <BrokenChild shouldThrow={true} />
+        </ErrorBoundary>,
+      )
+      expect(screen.getByText(/אופס! משהו קרה/)).toBeTruthy()
+    })
+
+    it('shows the Hebrew retry message on the button', () => {
+      render(
+        <ErrorBoundary>
+          <BrokenChild shouldThrow={true} />
+        </ErrorBoundary>,
+      )
+      expect(screen.getByText(/בוא ננסה שוב/)).toBeTruthy()
+    })
+
+    it('shows the English error message', () => {
+      render(
+        <ErrorBoundary>
+          <BrokenChild shouldThrow={true} />
+        </ErrorBoundary>,
+      )
+      expect(screen.getByText(/Oops! Something happened/)).toBeTruthy()
+    })
+
+    it('shows the English retry text on the button', () => {
+      render(
+        <ErrorBoundary>
+          <BrokenChild shouldThrow={true} />
+        </ErrorBoundary>,
+      )
+      expect(screen.getByText(/Let.s try again/)).toBeTruthy()
+    })
+
+    it('shows a Try Again button', () => {
+      render(
+        <ErrorBoundary>
+          <BrokenChild shouldThrow={true} />
+        </ErrorBoundary>,
+      )
+      expect(screen.getByRole('button', { name: /try again/i })).toBeTruthy()
+    })
+
+    it('shows the hedgehog emoji', () => {
+      render(
+        <ErrorBoundary>
+          <BrokenChild shouldThrow={true} />
+        </ErrorBoundary>,
+      )
+      expect(screen.getByRole('img', { name: /hedgehog/i })).toBeTruthy()
+    })
+  })
+
+  describe('Try Again resets error state', () => {
+    it('re-renders children after clicking Try Again (when child no longer throws)', () => {
+      // Use a wrapper to toggle shouldThrow after reset
+      function Wrapper() {
+        const [shouldThrow, setShouldThrow] = React.useState(true)
+
+        // Expose a way to stop throwing (simulates parent fixing state)
+        React.useEffect(() => {
+          // After the boundary resets, children render again — use a flag
+          window.__stopThrowing = () => setShouldThrow(false)
+          return () => { delete window.__stopThrowing }
+        }, [])
+
+        return (
+          <ErrorBoundary>
+            <BrokenChild shouldThrow={shouldThrow} />
+          </ErrorBoundary>
+        )
+      }
+
+      render(<Wrapper />)
+      // Fallback is visible
+      expect(screen.getByRole('alert')).toBeTruthy()
+
+      // Stop the child from throwing, then click Try Again
+      window.__stopThrowing()
+      fireEvent.click(screen.getByRole('button', { name: /try again/i }))
+
+      // Children should now render without error
+      expect(screen.getByTestId('healthy-child')).toBeTruthy()
+      expect(screen.queryByRole('alert')).toBeNull()
+    })
+
+    it('resets hasError to false when Try Again is clicked', () => {
+      // Even if child throws again, the click handler must fire and reset state
+      render(
+        <ErrorBoundary>
+          <BrokenChild shouldThrow={true} />
+        </ErrorBoundary>,
+      )
+      const button = screen.getByRole('button', { name: /try again/i })
+      // Should not throw during click handling
+      expect(() => fireEvent.click(button)).not.toThrow()
+    })
+  })
+
+  describe('security — no error details in rendered output', () => {
+    it('does not expose error.message in rendered output', () => {
+      render(
+        <ErrorBoundary>
+          <BrokenChild shouldThrow={true} />
+        </ErrorBoundary>,
+      )
+      const alert = screen.getByRole('alert')
+      expect(alert.textContent).not.toContain('secret-error-message')
+      expect(alert.textContent).not.toContain('db connection string xyz')
+    })
+
+    it('does not expose error.stack in rendered output', () => {
+      render(
+        <ErrorBoundary>
+          <BrokenChild shouldThrow={true} />
+        </ErrorBoundary>,
+      )
+      const alert = screen.getByRole('alert')
+      // Stack traces contain "at " function references
+      expect(alert.textContent).not.toContain('at BrokenChild')
+    })
+
+    it('does not expose componentStack in rendered output', () => {
+      render(
+        <ErrorBoundary>
+          <BrokenChild shouldThrow={true} />
+        </ErrorBoundary>,
+      )
+      const alert = screen.getByRole('alert')
+      // componentStack contains React component names
+      expect(alert.textContent).not.toContain('in BrokenChild')
+      expect(alert.textContent).not.toContain('in ErrorBoundary')
+    })
+  })
+
+  describe('error logging', () => {
+    it('logs the error to console.error', () => {
+      render(
+        <ErrorBoundary>
+          <BrokenChild shouldThrow={true} />
+        </ErrorBoundary>,
+      )
+      // At least one call should include our custom prefix
+      const wasCalled = consoleErrorSpy.mock.calls.some(
+        (args) => typeof args[0] === 'string' && args[0].includes('ErrorBoundary caught:'),
+      )
+      expect(wasCalled).toBe(true)
+    })
+
+    it('passes the error object as the second argument to console.error', () => {
+      render(
+        <ErrorBoundary>
+          <BrokenChild shouldThrow={true} />
+        </ErrorBoundary>,
+      )
+      const catchCall = consoleErrorSpy.mock.calls.find(
+        (args) => typeof args[0] === 'string' && args[0].includes('ErrorBoundary caught:'),
+      )
+      expect(catchCall).toBeTruthy()
+      expect(catchCall[1]).toBeInstanceOf(Error)
+    })
+  })
+})

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -2,6 +2,7 @@
  * React components for Math Trainer
  *
  * Sonic-themed UI components designed for 7-year-old children:
+ * - ErrorBoundary: Root-level error catcher with bilingual fallback UI
  * - Problem: Math problem display (e.g., "5 + 3 = ?")
  * - AnswerButtons: Grid of answer options
  * - ScoreDisplay: Current score and streak
@@ -16,6 +17,7 @@
  * - LevelUpScreen: Celebration screen when player levels up
  */
 
+export { default as ErrorBoundary } from './ErrorBoundary'
 export { default as Problem } from './Problem'
 export { default as AnswerButtons } from './AnswerButtons'
 export { default as ScoreDisplay } from './ScoreDisplay'

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -4,14 +4,17 @@ import { I18nextProvider } from 'react-i18next'
 import i18n from './i18n/index.js'
 import App from './App.jsx'
 import ProfileProvider from './context/ProfileContext.jsx'
+import ErrorBoundary from './components/ErrorBoundary.jsx'
 import './styles/index.css'
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
-    <I18nextProvider i18n={i18n}>
-      <ProfileProvider>
-        <App />
-      </ProfileProvider>
-    </I18nextProvider>
+    <ErrorBoundary>
+      <I18nextProvider i18n={i18n}>
+        <ProfileProvider>
+          <App />
+        </ProfileProvider>
+      </I18nextProvider>
+    </ErrorBoundary>
   </React.StrictMode>,
 )

--- a/src/main.test.jsx
+++ b/src/main.test.jsx
@@ -41,6 +41,10 @@ vi.mock('react-i18next', () => ({
   initReactI18next: { type: '3rdParty', init: vi.fn() },
 }))
 
+vi.mock('./components/ErrorBoundary.jsx', () => ({
+  default: function MockErrorBoundary({ children }) { return children },
+}))
+
 vi.mock('./styles/index.css', () => ({}))
 
 describe('main.jsx', () => {
@@ -65,15 +69,22 @@ describe('main.jsx', () => {
     expect(capturedElement).not.toBeNull()
   })
 
-  it('wraps App inside I18nextProvider inside ProfileProvider inside StrictMode', () => {
-    // The rendered element is: <StrictMode><I18nextProvider><ProfileProvider><App /></ProfileProvider></I18nextProvider></StrictMode>
+  it('wraps tree inside StrictMode at the root', () => {
     expect(capturedElement.type).toBe(React.StrictMode.type ?? React.StrictMode)
+  })
 
-    const i18nProviderElement = capturedElement.props.children
+  it('wraps App inside ErrorBoundary inside I18nextProvider inside ProfileProvider inside StrictMode', () => {
+    // Tree: <StrictMode><ErrorBoundary><I18nextProvider><ProfileProvider><App/></ProfileProvider></I18nextProvider></ErrorBoundary></StrictMode>
+    const strictModeChild = capturedElement.props.children // ErrorBoundary
+    expect(strictModeChild).toBeTruthy()
+
+    const i18nProviderElement = strictModeChild.props.children // I18nextProvider
     expect(i18nProviderElement).toBeTruthy()
-    // I18nextProvider wraps ProfileProvider which wraps App
-    const profileProviderElement = i18nProviderElement.props.children
+
+    const profileProviderElement = i18nProviderElement.props.children // ProfileProvider
     expect(profileProviderElement).toBeTruthy()
+
+    // ProfileProvider's child is App
     expect(profileProviderElement.props.children).toBeTruthy()
   })
 })


### PR DESCRIPTION
Closes #124

Part of epic #117 (Phase 0 — Critical Safety + Infrastructure)

## Summary

- New `ErrorBoundary` class component at `src/components/ErrorBoundary.jsx`
- Wraps at `main.jsx` root level, above all providers
- Hardcoded bilingual fallback (no i18n dependency — provider may be crash source)

## Acceptance Criteria

- [ ] Catches render errors anywhere in the component tree
- [ ] Shows a child-friendly fallback message (Hebrew + English, no stack trace exposed)
- [ ] "Try Again" button resets error state and re-renders the tree
- [ ] No stack trace or internal error details exposed to the user

## Notes

Fallback text is hardcoded (not via `react-i18next`) because the i18n provider itself may be the source of the crash. Wrapping above all providers ensures coverage of every failure mode.