### PR TITLE
feat: fix dead-end states and auth error flow (#125)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -59,6 +59,9 @@ function App() {
   // Track which level was just completed (for LevelUpScreen)
   const [completedLevel, setCompletedLevel] = useState(null)
 
+  // Track whether the auth error has been dismissed via "Play Anyway"
+  const [errorDismissed, setErrorDismissed] = useState(false)
+
   // Combine loading states
   const loading = profileLoading || authLoading || progressLoading
 
@@ -187,7 +190,14 @@ function App() {
   }
 
   // Show error state if authentication failed (user can still play, progress won't persist)
-  if (authError) {
+  if (authError && !errorDismissed) {
+    const errorCode = authError.code ?? ''
+    const errorMsgKey =
+      errorCode === 'auth/network-request-failed' ? 'app.errors.network'
+        : errorCode === 'auth/too-many-requests' ? 'app.errors.tooManyRequests'
+          : errorCode === 'auth/internal-error' ? 'app.errors.internal'
+            : 'app.errors.generic'
+
     return (
       <div className="min-h-screen bg-gradient-to-b from-sonic-blue to-blue-900 flex flex-col items-center justify-center p-4">
         <div className="text-center">
@@ -198,10 +208,13 @@ function App() {
             {t('app.errorConnection')}
           </p>
           <p className="text-sm text-white mt-2 opacity-75">
-            {authError.message}
+            {t(errorMsgKey)}
           </p>
           <button
-            onClick={() => setScreen('game')}
+            onClick={() => {
+              setErrorDismissed(true)
+              setScreen('game')
+            }}
             className="mt-6 bg-sonic-gold text-sonic-blue font-game px-8 py-4 rounded-full
                        hover:bg-yellow-400 transform hover:scale-105 transition-all
                        shadow-lg active:scale-95 text-xl"

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -355,7 +355,7 @@ describe('App', () => {
       render(<App />)
 
       expect(screen.getByText('Oops!')).toBeTruthy()
-      expect(screen.getByText('Auth failed')).toBeTruthy()
+      expect(screen.getByText('Connection error')).toBeTruthy()
     })
 
     it('offers "Play Anyway" button on auth error', () => {

--- a/src/components/GameScreen.jsx
+++ b/src/components/GameScreen.jsx
@@ -1,9 +1,11 @@
-import { useEffect } from 'react'
+import { useEffect, useState, useRef } from 'react'
 import PropTypes from 'prop-types'
 import { useTranslation } from 'react-i18next'
 import { Problem, AnswerButtons, ScoreDisplay, Feedback } from './index'
 import { LearningAid } from './aids'
 import { useGameState } from '../hooks'
+
+const STUCK_TIMEOUT_MS = 10000
 
 /**
  * GameScreen Component - Main game interface for Math Trainer
@@ -25,8 +27,9 @@ import { useGameState } from '../hooks'
  * @param {number} currentLevel - Current difficulty level (1-13, default 1)
  * @param {function} onLevelUp - Optional callback when confidence engine signals level-up
  * @param {object} activeProfile - Optional active profile (provides theme)
+ * @param {number} stuckTimeoutMs - Timeout before showing "Go Back" (default 10000, injectable for tests)
  */
-function GameScreen({ onGameEnd, updateProgress = null, initialProgress = null, currentLevel = 1, onLevelUp, activeProfile = null }) {
+function GameScreen({ onGameEnd, updateProgress = null, initialProgress = null, currentLevel = 1, onLevelUp, activeProfile = null, stuckTimeoutMs = STUCK_TIMEOUT_MS }) {
   const { t } = useTranslation()
   const {
     currentProblem,
@@ -45,6 +48,10 @@ function GameScreen({ onGameEnd, updateProgress = null, initialProgress = null, 
     shouldLevelUp,
   } = useGameState({ currentLevel, updateProgress, initialProgress })
 
+  // Timeout dead-end: show "Go Back" after stuckTimeoutMs of no interaction
+  const [showStuck, setShowStuck] = useState(false)
+  const stuckTimerRef = useRef(null)
+
   // Detect level-up: when confidence engine signals shouldLevelUp AND feedback
   // animation has cleared, notify the parent (App) to transition to LevelUpScreen.
   // The parent unmounts GameScreen, so no race condition with auto-advance.
@@ -53,6 +60,23 @@ function GameScreen({ onGameEnd, updateProgress = null, initialProgress = null, 
       onLevelUp(currentLevel)
     }
   }, [shouldLevelUp, showFeedback, onLevelUp, currentLevel])
+
+  // Start stuck timer on mount and reset whenever totalProblems changes
+  // (new problem presented) or showFeedback changes (user interacted).
+  useEffect(() => {
+    setShowStuck(false)
+    if (stuckTimerRef.current) {
+      clearTimeout(stuckTimerRef.current)
+    }
+    stuckTimerRef.current = setTimeout(() => {
+      setShowStuck(true)
+    }, stuckTimeoutMs)
+    return () => {
+      if (stuckTimerRef.current) {
+        clearTimeout(stuckTimerRef.current)
+      }
+    }
+  }, [totalProblems, showFeedback, stuckTimeoutMs])
 
   // Start game automatically if not playing
   // This handles the initial mount
@@ -144,6 +168,28 @@ function GameScreen({ onGameEnd, updateProgress = null, initialProgress = null, 
       {/* Footer Spacer - Ensures content doesn't touch bottom */}
       <footer className="h-8 md:h-12" aria-hidden="true" />
 
+      {/* Stuck Timeout - Non-intrusive "Go Back" escape hatch */}
+      {showStuck && (
+        <div
+          className="absolute bottom-6 left-1/2 -translate-x-1/2 flex flex-col items-center gap-2"
+          data-testid="stuck-banner"
+        >
+          <p className="text-white/80 font-game text-sm">{t('app.game.stuck')}</p>
+          <button
+            onClick={() => onGameEnd(null)}
+            className="
+              bg-white/20 hover:bg-white/30 text-white font-game text-sm
+              px-6 py-2 rounded-full border border-white/40
+              transform transition-all duration-200 hover:scale-105 active:scale-95
+              focus:outline-none focus:ring-2 focus:ring-white/50
+            "
+            data-testid="go-back-button"
+          >
+            {t('app.game.goBack')}
+          </button>
+        </div>
+      )}
+
       {/* Feedback Overlay - Shows on answer */}
       {showFeedback && (
         <Feedback isCorrect={isCorrect} />
@@ -166,6 +212,7 @@ GameScreen.propTypes = {
   activeProfile: PropTypes.shape({
     theme: PropTypes.string,
   }),
+  stuckTimeoutMs: PropTypes.number,
 }
 
 export default GameScreen

--- a/src/components/__tests__/dead-end-auth.test.jsx
+++ b/src/components/__tests__/dead-end-auth.test.jsx
@@ -1,0 +1,364 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Tests for sub-issue #125: dead-end states and auth error flow.
+ *
+ * Covers:
+ * - GameScreen shows "Go Back" button after 10s of no interaction
+ * - GameScreen resets timeout when a new problem is presented
+ * - Auth error shows translated message (not raw Firebase error string)
+ * - "Play Anyway" dismisses the error and navigates to the game screen
+ * - Error page does not reappear after dismissal
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, act, cleanup, waitFor } from '@testing-library/react'
+import { createElement } from 'react'
+
+// ── Mock state objects (mutated by tests) ─────────────────────────────────────
+
+const mockGameState = {
+  currentProblem: { num1: 3, num2: 2, operator: '+', correctAnswer: 5, options: [3, 4, 5, 6] },
+  score: 0,
+  streak: 0,
+  bestStreak: 0,
+  showFeedback: false,
+  isCorrect: false,
+  handleAnswer: vi.fn(),
+  startGame: vi.fn(),
+  isPlaying: true,
+  totalProblems: 0,
+  correctAnswers: 0,
+  accuracy: 0,
+  isStruggling: false,
+  shouldLevelUp: false,
+}
+
+const mockFirebase = {
+  user: { uid: 'test-uid' },
+  loading: false,
+  error: null,
+}
+
+const mockProfileContext = {
+  activeProfile: {
+    id: '1',
+    nickname: 'Dubi',
+    firebaseUid: 'uid-1',
+    currentLevel: 1,
+  },
+  isLoading: false,
+  clearActiveProfile: vi.fn(),
+  createAndActivate: vi.fn(),
+  updateProfile: vi.fn(),
+}
+
+// ── Module mocks ──────────────────────────────────────────────────────────────
+
+vi.mock('../../config/levels', () => ({
+  MAX_LEVEL: 13,
+}))
+
+vi.mock('../../context/useProfile', () => ({
+  useProfile: () => mockProfileContext,
+}))
+
+vi.mock('../../hooks', () => ({
+  useGameState: () => mockGameState,
+  useFirebase: () => mockFirebase,
+  useGameProgress: () => ({
+    progress: { score: 0, streak: 0, totalProblems: 0, correctAnswers: 0 },
+    updateProgress: vi.fn(),
+    forceSave: vi.fn(),
+    loading: false,
+  }),
+}))
+
+// GameScreen imports child components from '../index' (i.e. src/components/index).
+// App imports the same barrel as '../../components' from App.jsx's location.
+// Both paths resolve to the same module, so one vi.mock covers both.
+vi.mock('../index', () => ({
+  // GameScreen children
+  Problem: ({ num1, num2, operator }) =>
+    createElement('div', { 'data-testid': 'problem' }, `${num1} ${operator} ${num2}`),
+  AnswerButtons: ({ options, onAnswer, disabled }) =>
+    createElement(
+      'div',
+      { 'data-testid': 'answer-buttons' },
+      options.map((opt) =>
+        createElement('button', {
+          key: opt,
+          'data-testid': `answer-${opt}`,
+          onClick: () => onAnswer(opt),
+          disabled,
+        }, opt)
+      )
+    ),
+  ScoreDisplay: ({ score, streak }) =>
+    createElement('div', { 'data-testid': 'score-display' }, `Score: ${score} Streak: ${streak}`),
+  Feedback: ({ isCorrect }) =>
+    createElement('div', { 'data-testid': 'feedback' }, isCorrect ? 'Correct!' : 'Wrong!'),
+  // App-level screen stubs (App imports this same barrel as '../../components')
+  StartScreen: () => createElement('div', { 'data-testid': 'start-screen' }),
+  GameScreen: ({ onGameEnd }) =>
+    createElement(
+      'div',
+      { 'data-testid': 'game-screen' },
+      createElement('button', { 'data-testid': 'exit-game', onClick: () => onGameEnd(null) }, 'Exit'),
+    ),
+  ResultScreen: () => createElement('div', { 'data-testid': 'result-screen' }),
+  LevelUpScreen: () => createElement('div', { 'data-testid': 'levelup-screen' }),
+  ProfileSwitcher: () => createElement('div', { 'data-testid': 'profile-switcher' }),
+  CreateProfile: () => createElement('div', { 'data-testid': 'create-profile-wizard' }),
+}))
+
+vi.mock('../aids', () => ({
+  LearningAid: () => createElement('div', { 'data-testid': 'learning-aid' }),
+}))
+
+// ── Import components after all mocks are registered ─────────────────────────
+
+const { default: GameScreen } = await import('../GameScreen')
+const { default: App } = await import('../../App')
+
+// ── Default props for GameScreen ──────────────────────────────────────────────
+
+// Use a very short timeout (50ms) to avoid fake timer complexity.
+// This tests the behavior without caring about the exact 10s duration.
+const STUCK_TIMEOUT_TEST_MS = 50
+
+const defaultGameScreenProps = {
+  onGameEnd: vi.fn(),
+  updateProgress: vi.fn(),
+  initialProgress: null,
+  currentLevel: 1,
+  onLevelUp: vi.fn(),
+  stuckTimeoutMs: STUCK_TIMEOUT_TEST_MS,
+}
+
+// ── Suite: GameScreen timeout (dead-end fix) ──────────────────────────────────
+
+describe('GameScreen timeout dead-end fix', () => {
+  beforeEach(() => {
+    cleanup()
+    vi.clearAllMocks()
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout', 'setInterval', 'clearInterval'] })
+    mockGameState.currentProblem = { num1: 3, num2: 2, operator: '+', correctAnswer: 5, options: [3, 4, 5, 6] }
+    mockGameState.score = 0
+    mockGameState.streak = 0
+    mockGameState.bestStreak = 0
+    mockGameState.showFeedback = false
+    mockGameState.isCorrect = false
+    mockGameState.isPlaying = true
+    mockGameState.totalProblems = 0
+    mockGameState.correctAnswers = 0
+    mockGameState.accuracy = 0
+    mockGameState.isStruggling = false
+    mockGameState.shouldLevelUp = false
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('does NOT show "Go Back" button before the timeout', () => {
+    render(<GameScreen {...defaultGameScreenProps} />)
+
+    act(() => {
+      vi.advanceTimersByTime(STUCK_TIMEOUT_TEST_MS - 1)
+    })
+
+    expect(screen.queryByTestId('go-back-button')).toBeNull()
+    expect(screen.queryByTestId('stuck-banner')).toBeNull()
+  })
+
+  it('shows "Go Back" button after the timeout with no interaction', async () => {
+    render(<GameScreen {...defaultGameScreenProps} />)
+
+    await act(async () => {
+      vi.advanceTimersByTime(STUCK_TIMEOUT_TEST_MS)
+    })
+
+    expect(screen.getByTestId('go-back-button')).toBeTruthy()
+    expect(screen.getByTestId('stuck-banner')).toBeTruthy()
+  })
+
+  it('shows stuck message text alongside the "Go Back" button', async () => {
+    render(<GameScreen {...defaultGameScreenProps} />)
+
+    await act(async () => {
+      vi.advanceTimersByTime(STUCK_TIMEOUT_TEST_MS)
+    })
+
+    expect(screen.getByText('Having trouble?')).toBeTruthy()
+    expect(screen.getByText('Go Back')).toBeTruthy()
+  })
+
+  it('calls onGameEnd(null) when "Go Back" button is clicked', async () => {
+    const onGameEnd = vi.fn()
+    render(<GameScreen {...defaultGameScreenProps} onGameEnd={onGameEnd} />)
+
+    await act(async () => {
+      vi.advanceTimersByTime(STUCK_TIMEOUT_TEST_MS)
+    })
+
+    fireEvent.click(screen.getByTestId('go-back-button'))
+    expect(onGameEnd).toHaveBeenCalledTimes(1)
+    expect(onGameEnd).toHaveBeenCalledWith(null)
+  })
+
+  it('resets timeout (hides stuck banner) when a new problem is shown', async () => {
+    const { rerender } = render(<GameScreen {...defaultGameScreenProps} />)
+
+    // Advance partway through the timeout
+    await act(async () => {
+      vi.advanceTimersByTime(STUCK_TIMEOUT_TEST_MS - 10)
+    })
+
+    // Simulate a new problem arriving by changing totalProblems
+    mockGameState.totalProblems = 1
+    rerender(<GameScreen {...defaultGameScreenProps} />)
+
+    // Advance only partway through the fresh timer — should NOT show stuck
+    await act(async () => {
+      vi.advanceTimersByTime(STUCK_TIMEOUT_TEST_MS - 10)
+    })
+
+    // Stuck banner should NOT be visible (timer was reset)
+    expect(screen.queryByTestId('stuck-banner')).toBeNull()
+  })
+
+  it('shows stuck banner again after full timeout from last problem reset', async () => {
+    const { rerender } = render(<GameScreen {...defaultGameScreenProps} />)
+
+    // Advance partway, then a new problem arrives
+    await act(async () => {
+      vi.advanceTimersByTime(STUCK_TIMEOUT_TEST_MS - 10)
+    })
+    mockGameState.totalProblems = 1
+    rerender(<GameScreen {...defaultGameScreenProps} />)
+
+    // Advance full timeout from reset point
+    await act(async () => {
+      vi.advanceTimersByTime(STUCK_TIMEOUT_TEST_MS)
+    })
+
+    expect(screen.getByTestId('stuck-banner')).toBeTruthy()
+  })
+})
+
+// ── Suite: Auth error mapping ─────────────────────────────────────────────────
+
+describe('auth error mapping and Play Anyway fix', () => {
+  beforeEach(() => {
+    cleanup()
+    vi.clearAllMocks()
+    mockFirebase.user = { uid: 'test-uid' }
+    mockFirebase.loading = false
+    mockFirebase.error = null
+    mockProfileContext.activeProfile = {
+      id: '1',
+      nickname: 'Dubi',
+      firebaseUid: 'uid-1',
+      currentLevel: 1,
+    }
+    mockProfileContext.isLoading = false
+  })
+
+  it('shows translated message for network error (not raw Firebase string)', () => {
+    mockFirebase.error = {
+      message: 'Firebase: Error (auth/network-request-failed).',
+      code: 'auth/network-request-failed',
+    }
+    render(<App />)
+
+    expect(screen.getByText('No internet connection')).toBeTruthy()
+    expect(screen.queryByText('Firebase: Error (auth/network-request-failed).')).toBeNull()
+  })
+
+  it('shows translated message for too-many-requests error', () => {
+    mockFirebase.error = {
+      message: 'Firebase: Too many requests.',
+      code: 'auth/too-many-requests',
+    }
+    render(<App />)
+
+    expect(screen.getByText('Too many attempts, try again later')).toBeTruthy()
+  })
+
+  it('shows translated message for internal error', () => {
+    mockFirebase.error = {
+      message: 'Firebase: Internal error.',
+      code: 'auth/internal-error',
+    }
+    render(<App />)
+
+    expect(screen.getByText('Something went wrong')).toBeTruthy()
+  })
+
+  it('shows generic translated message for unknown error code', () => {
+    mockFirebase.error = {
+      message: 'Some unexpected Firebase error.',
+      code: 'auth/unknown-code',
+    }
+    render(<App />)
+
+    expect(screen.getByText('Connection error')).toBeTruthy()
+    expect(screen.queryByText('Some unexpected Firebase error.')).toBeNull()
+  })
+
+  it('shows generic translated message when error has no code', () => {
+    mockFirebase.error = {
+      message: 'Unknown error',
+    }
+    render(<App />)
+
+    expect(screen.getByText('Connection error')).toBeTruthy()
+  })
+
+  it('"Play Anyway" button navigates to the game screen', () => {
+    mockFirebase.error = {
+      message: 'Firebase: Error (auth/network-request-failed).',
+      code: 'auth/network-request-failed',
+    }
+    render(<App />)
+
+    expect(screen.getByText('Play Anyway!')).toBeTruthy()
+    fireEvent.click(screen.getByText('Play Anyway!'))
+
+    expect(screen.getByTestId('game-screen')).toBeTruthy()
+  })
+
+  it('error page does NOT reappear after "Play Anyway" is clicked', () => {
+    mockFirebase.error = {
+      message: 'Firebase: Error (auth/network-request-failed).',
+      code: 'auth/network-request-failed',
+    }
+    render(<App />)
+
+    fireEvent.click(screen.getByText('Play Anyway!'))
+
+    // Auth error screen should be gone
+    expect(screen.queryByText('Oops!')).toBeNull()
+    expect(screen.queryByText('Play Anyway!')).toBeNull()
+
+    // Game screen should be present
+    expect(screen.getByTestId('game-screen')).toBeTruthy()
+  })
+
+  it('game screen stays accessible after dismissal even though authError is still set', () => {
+    mockFirebase.error = {
+      message: 'Firebase: Internal error.',
+      code: 'auth/internal-error',
+    }
+    render(<App />)
+
+    // Dismiss error
+    fireEvent.click(screen.getByText('Play Anyway!'))
+    expect(screen.getByTestId('game-screen')).toBeTruthy()
+
+    // Exiting the game should go to start screen, not error screen
+    fireEvent.click(screen.getByTestId('exit-game'))
+    expect(screen.getByTestId('start-screen')).toBeTruthy()
+    expect(screen.queryByText('Oops!')).toBeNull()
+  })
+})

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -6,7 +6,17 @@
     "loadingProgress": "Loading your progress...",
     "errorTitle": "Oops!",
     "errorConnection": "Could not connect to save your progress",
-    "playAnyway": "Play Anyway!"
+    "playAnyway": "Play Anyway!",
+    "errors": {
+      "network": "No internet connection",
+      "tooManyRequests": "Too many attempts, try again later",
+      "internal": "Something went wrong",
+      "generic": "Connection error"
+    },
+    "game": {
+      "stuck": "Having trouble?",
+      "goBack": "Go Back"
+    }
   },
   "start": {
     "title": "Sonic Math Trainer!",

--- a/src/i18n/locales/he.json
+++ b/src/i18n/locales/he.json
@@ -6,7 +6,17 @@
     "loadingProgress": "טוען את ההתקדמות שלך...",
     "errorTitle": "אופס!",
     "errorConnection": "לא הצלחנו לשמור את ההתקדמות שלך",
-    "playAnyway": "בוא נשחק!"
+    "playAnyway": "בוא נשחק!",
+    "errors": {
+      "network": "אין חיבור לאינטרנט",
+      "tooManyRequests": "יותר מדי נסיונות, נסה מאוחר יותר",
+      "internal": "משהו השתבש",
+      "generic": "שגיאת חיבור"
+    },
+    "game": {
+      "stuck": "נתקעת?",
+      "goBack": "חזור"
+    }
   },
   "start": {
     "title": "סוניק מתמטיקה!",


### PR DESCRIPTION
Sub-issue of #117. Fixes GameScreen timeout dead-end and improves auth error handling.

## Changes

- **GameScreen timeout**: shows "Go Back" button after 10 seconds with no interaction; resets on each new problem; calls `onGameEnd(null)` to exit cleanly
- **Auth error mapping**: replaces raw Firebase error strings with user-friendly translated messages using `app.errors.*` keys
- **Play Anyway fix**: adds `errorDismissed` state so clicking "Play Anyway" permanently dismisses the auth error screen for the session
- **i18n**: new keys in `he.json` and `en.json` for `app.errors.*` and `app.game.*`
- **Tests**: 14 new tests in `dead-end-auth.test.jsx`; updated `App.test.jsx` for translated error assertion

## Test plan

- [ ] All 897 tests pass (`npx vitest run`)
- [ ] No ESLint warnings on changed files
- [ ] GameScreen renders "Go Back" after 10s idle (injectable `stuckTimeoutMs` prop used in tests)
- [ ] Auth errors show translated strings, not raw Firebase messages
- [ ] "Play Anyway" navigates to game and does not show error again