### PR TITLE
#145 Level Schema + Data Definition (20 levels, grades 1-3)

### DIFF
--- a/src/components/LevelMap.test.jsx
+++ b/src/components/LevelMap.test.jsx
@@ -25,21 +25,21 @@ describe('LevelMap', () => {
     vi.restoreAllMocks()
   })
 
-  // ── Renders all 13 level nodes ──────────────────────────────────────
+  // ── Renders all 20 level nodes ──────────────────────────────────────
 
-  it('renders 13 level nodes', () => {
+  it('renders 20 level nodes', () => {
     renderLevelMap({ currentLevel: 1 })
     const items = screen.getAllByRole('listitem')
-    expect(items).toHaveLength(13)
+    expect(items).toHaveLength(20)
   })
 
   // ── Level names displayed ───────────────────────────────────────────
 
   it('displays level names below each node', () => {
     renderLevelMap({ currentLevel: 1 })
-    expect(screen.getByText('First Steps')).toBeTruthy()
-    expect(screen.getByText('Addition Hero')).toBeTruthy()
-    expect(screen.getByText('Math Champion')).toBeTruthy()
+    expect(screen.getByText('Add within 5')).toBeTruthy()
+    expect(screen.getByText('Subtract within 5')).toBeTruthy()
+    expect(screen.getByText('Mixed All Ops (to 1000)')).toBeTruthy()
   })
 
   // ── Completed levels (< currentLevel) ───────────────────────────────
@@ -120,25 +120,25 @@ describe('LevelMap', () => {
     it('each node has role="listitem"', () => {
       renderLevelMap({ currentLevel: 1 })
       const items = screen.getAllByRole('listitem')
-      expect(items).toHaveLength(13)
+      expect(items).toHaveLength(20)
     })
 
     it('completed level has correct aria-label', () => {
       renderLevelMap({ currentLevel: 3 })
       const node1 = screen.getByTestId('level-node-1')
-      expect(node1.getAttribute('aria-label')).toBe('Level 1: First Steps - completed')
+      expect(node1.getAttribute('aria-label')).toBe('Level 1: Add within 5 - completed')
     })
 
     it('current level has correct aria-label', () => {
       renderLevelMap({ currentLevel: 3 })
       const node3 = screen.getByTestId('level-node-3')
-      expect(node3.getAttribute('aria-label')).toBe('Level 3: Minus Magic - current')
+      expect(node3.getAttribute('aria-label')).toBe('Level 3: Add to 10 - current')
     })
 
     it('locked level has correct aria-label', () => {
       renderLevelMap({ currentLevel: 3 })
       const node4 = screen.getByTestId('level-node-4')
-      expect(node4.getAttribute('aria-label')).toBe('Level 4: Mixed Warrior - locked')
+      expect(node4.getAttribute('aria-label')).toBe('Level 4: Mixed +/- to 10 - locked')
     })
   })
 
@@ -161,21 +161,21 @@ describe('LevelMap', () => {
       renderLevelMap({ currentLevel: 1 })
       // Level 1 is current (gold)
       const node1 = screen.getByTestId('level-node-1')
-      expect(node1.getAttribute('aria-label')).toBe('Level 1: First Steps - current')
+      expect(node1.getAttribute('aria-label')).toBe('Level 1: Add within 5 - current')
       // Level 2 is locked
       const node2 = screen.getByTestId('level-node-2')
-      expect(node2.getAttribute('aria-label')).toBe('Level 2: Addition Hero - locked')
+      expect(node2.getAttribute('aria-label')).toBe('Level 2: Subtract within 5 - locked')
     })
 
-    it('currentLevel=13 — 12 completed, last is current, none locked', () => {
-      renderLevelMap({ currentLevel: 13 })
-      // Level 12 is completed
-      const node12 = screen.getByTestId('level-node-12')
-      expect(node12.getAttribute('aria-label')).toBe('Level 12: Division Quest - completed')
-      // Level 13 is current
-      const node13 = screen.getByTestId('level-node-13')
-      expect(node13.getAttribute('aria-label')).toBe('Level 13: Math Champion - current')
-      // No locked levels - all 13 are either completed or current
+    it('currentLevel=20 — 19 completed, last is current, none locked', () => {
+      renderLevelMap({ currentLevel: 20 })
+      // Level 19 is completed
+      const node19 = screen.getByTestId('level-node-19')
+      expect(node19.getAttribute('aria-label')).toBe('Level 19: Division Mastery - completed')
+      // Level 20 is current
+      const node20 = screen.getByTestId('level-node-20')
+      expect(node20.getAttribute('aria-label')).toBe('Level 20: Mixed All Ops (to 1000) - current')
+      // No locked levels - all 20 are either completed or current
       const items = screen.getAllByRole('listitem')
       const lockedItems = items.filter(
         item => item.getAttribute('aria-label')?.includes('locked')
@@ -206,8 +206,8 @@ describe('LevelMap', () => {
     it('renders connecting lines between nodes', () => {
       renderLevelMap({ currentLevel: 1 })
       const lines = screen.getByTestId('level-map').querySelectorAll('[data-testid^="connector-"]')
-      // 12 connectors between 13 nodes
-      expect(lines).toHaveLength(12)
+      // 19 connectors between 20 nodes
+      expect(lines).toHaveLength(19)
     })
   })
 
@@ -217,7 +217,7 @@ describe('LevelMap', () => {
     it('renders without currentLevel prop (defaults handled gracefully)', () => {
       render(<LevelMap />)
       const items = screen.getAllByRole('listitem')
-      expect(items).toHaveLength(13)
+      expect(items).toHaveLength(20)
     })
   })
 })

--- a/src/components/StartScreen.test.jsx
+++ b/src/components/StartScreen.test.jsx
@@ -63,19 +63,19 @@ describe('StartScreen — LevelMap integration', () => {
     renderStartScreen({ currentLevel: 5 })
     // Level 5 should be current
     const node5 = screen.getByTestId('level-node-5')
-    expect(node5.getAttribute('aria-label')).toBe('Level 5: Cross the 10 - current')
+    expect(node5.getAttribute('aria-label')).toBe('Level 5: Bridge the 10 (Add) - current')
   })
 
-  it('renders 13 level nodes inside LevelMap', () => {
+  it('renders 20 level nodes inside LevelMap', () => {
     renderStartScreen({ currentLevel: 1 })
     const items = screen.getAllByRole('listitem')
-    expect(items).toHaveLength(13)
+    expect(items).toHaveLength(20)
   })
 
   it('defaults currentLevel to 1 when not provided', () => {
     render(<StartScreen onStart={vi.fn()} />)
     const node1 = screen.getByTestId('level-node-1')
-    expect(node1.getAttribute('aria-label')).toBe('Level 1: First Steps - current')
+    expect(node1.getAttribute('aria-label')).toBe('Level 1: Add within 5 - current')
   })
 })
 

--- a/src/config/levels.js
+++ b/src/config/levels.js
@@ -1,30 +1,296 @@
-/** Total number of levels — use this instead of magic number 13 */
-export const MAX_LEVEL = 13
+export const OPERATION_TYPES = Object.freeze({
+  INTEGER_ARITHMETIC: 'integer-arithmetic',
+  DIVISION_WITH_REMAINDER: 'division-with-remainder',
+  FRACTION: 'fraction',
+  DECIMAL: 'decimal',
+  PERCENTAGE: 'percentage',
+  ORDER_OF_OPERATIONS: 'order-of-operations',
+})
+
+export const GRADES = Object.freeze({
+  GRADE_1: 1,
+  GRADE_2: 2,
+  GRADE_3: 3,
+  GRADE_4: 4,
+  GRADE_5: 5,
+  GRADE_6: 6,
+})
 
 export const LEVELS = [
-  { id: 1,  name: 'First Steps',     operators: ['+'],           minNumber: 1, maxNumber: 5,   ageTarget: '5-6'  },
-  { id: 2,  name: 'Addition Hero',   operators: ['+'],           minNumber: 1, maxNumber: 10,  ageTarget: '6'    },
-  { id: 3,  name: 'Minus Magic',     operators: ['-'],           minNumber: 1, maxNumber: 10,  ageTarget: '6-7'  },
-  { id: 4,  name: 'Mixed Warrior',   operators: ['+', '-'],      minNumber: 1, maxNumber: 10,  ageTarget: '7'    },
-  { id: 5,  name: 'Cross the 10',    operators: ['+'],           minNumber: 1, maxNumber: 20,  ageTarget: '7'    },
-  { id: 6,  name: 'Subtract 20',     operators: ['-'],           minNumber: 1, maxNumber: 20,  ageTarget: '7-8'  },
-  { id: 7,  name: 'Mixed 20',        operators: ['+', '-'],      minNumber: 1, maxNumber: 20,  ageTarget: '8'    },
-  { id: 8,  name: 'Tens Master',     operators: ['+', '-'],      minNumber: 10, maxNumber: 100, ageTarget: '8-9', multiplesOf: 10 },
-  { id: 9,  name: 'Century Runner',  operators: ['+', '-'],      minNumber: 1, maxNumber: 100, ageTarget: '9'    },
-  { id: 10, name: 'Speed of 2s',     operators: ['*'],           minNumber: 2, maxNumber: 10,  ageTarget: '9-10', multipliers: [2,5,10] },
-  { id: 11, name: 'Times Tables',    operators: ['*'],           minNumber: 2, maxNumber: 10,  ageTarget: '10-11', multipliers: [3,4,6,7,8,9] },
-  { id: 12, name: 'Division Quest',  operators: ['/'],           minNumber: 2, maxNumber: 10,  ageTarget: '11-12', divisors: [2,5,10] },
-  { id: 13, name: 'Math Champion',   operators: ['+','-','*','/'], minNumber: 1, maxNumber: 100, ageTarget: '12-13' },
+  // ── Grade 1 (8 levels) ─────────────────────────────────────────────────────
+  {
+    id: 1,
+    grade: 1,
+    name: 'Add within 5',
+    nameHe: 'חיבור עד 5',
+    operationType: OPERATION_TYPES.INTEGER_ARITHMETIC,
+    operators: ['+'],
+    numberRange: { min: 0, max: 5 },
+    ageTarget: '6',
+    levelVersion: 2,
+  },
+  {
+    id: 2,
+    grade: 1,
+    name: 'Subtract within 5',
+    nameHe: 'חיסור עד 5',
+    operationType: OPERATION_TYPES.INTEGER_ARITHMETIC,
+    operators: ['-'],
+    numberRange: { min: 0, max: 5 },
+    ageTarget: '6',
+    levelVersion: 2,
+  },
+  {
+    id: 3,
+    grade: 1,
+    name: 'Add to 10',
+    nameHe: 'חיבור עד 10',
+    operationType: OPERATION_TYPES.INTEGER_ARITHMETIC,
+    operators: ['+'],
+    numberRange: { min: 0, max: 10 },
+    ageTarget: '6',
+    levelVersion: 2,
+  },
+  {
+    id: 4,
+    grade: 1,
+    name: 'Mixed +/- to 10',
+    nameHe: 'חיבור וחיסור עד 10',
+    operationType: OPERATION_TYPES.INTEGER_ARITHMETIC,
+    operators: ['+', '-'],
+    numberRange: { min: 0, max: 10 },
+    ageTarget: '6-7',
+    levelVersion: 2,
+  },
+  {
+    id: 5,
+    grade: 1,
+    name: 'Bridge the 10 (Add)',
+    nameHe: 'חציית ה-10 (חיבור)',
+    operationType: OPERATION_TYPES.INTEGER_ARITHMETIC,
+    operators: ['+'],
+    numberRange: { min: 1, max: 20 },
+    ageTarget: '7',
+    levelVersion: 2,
+  },
+  {
+    id: 6,
+    grade: 1,
+    name: 'Bridge the 10 (Sub)',
+    nameHe: 'חציית ה-10 (חיסור)',
+    operationType: OPERATION_TYPES.INTEGER_ARITHMETIC,
+    operators: ['-'],
+    numberRange: { min: 1, max: 20 },
+    ageTarget: '7',
+    levelVersion: 2,
+  },
+  {
+    id: 7,
+    grade: 1,
+    name: 'Mixed +/- to 20',
+    nameHe: 'חיבור וחיסור עד 20',
+    operationType: OPERATION_TYPES.INTEGER_ARITHMETIC,
+    operators: ['+', '-'],
+    numberRange: { min: 1, max: 20 },
+    ageTarget: '7',
+    levelVersion: 2,
+  },
+  {
+    id: 8,
+    grade: 1,
+    name: 'Tens Structure',
+    nameHe: 'מבנה העשרות',
+    operationType: OPERATION_TYPES.INTEGER_ARITHMETIC,
+    operators: ['+', '-'],
+    numberRange: { min: 10, max: 100 },
+    ageTarget: '7',
+    levelVersion: 2,
+    multiplesOf: 10,
+  },
+  // ── Grade 2 (6 levels) ─────────────────────────────────────────────────────
+  {
+    id: 9,
+    grade: 2,
+    name: 'Automaticity +/- to 20',
+    nameHe: 'אוטומטיות עד 20',
+    operationType: OPERATION_TYPES.INTEGER_ARITHMETIC,
+    operators: ['+', '-'],
+    numberRange: { min: 1, max: 20 },
+    ageTarget: '7-8',
+    levelVersion: 2,
+  },
+  {
+    id: 10,
+    grade: 2,
+    name: 'Multiply ×2,×5,×10',
+    nameHe: 'כפל ב-2, 5, 10',
+    operationType: OPERATION_TYPES.INTEGER_ARITHMETIC,
+    operators: ['*'],
+    numberRange: { min: 1, max: 10 },
+    ageTarget: '8',
+    levelVersion: 2,
+    multipliers: [2, 5, 10],
+  },
+  {
+    id: 11,
+    grade: 2,
+    name: 'Times Tables ×3,×4',
+    nameHe: 'לוח הכפל ×3, ×4',
+    operationType: OPERATION_TYPES.INTEGER_ARITHMETIC,
+    operators: ['*'],
+    numberRange: { min: 1, max: 10 },
+    ageTarget: '8',
+    levelVersion: 2,
+    multipliers: [3, 4],
+  },
+  {
+    id: 12,
+    grade: 2,
+    name: 'Easy Division',
+    nameHe: 'חילוק קל',
+    operationType: OPERATION_TYPES.INTEGER_ARITHMETIC,
+    operators: ['/'],
+    numberRange: { min: 1, max: 100 },
+    ageTarget: '8',
+    levelVersion: 2,
+    divisors: [2, 5, 10],
+  },
+  {
+    id: 13,
+    grade: 2,
+    name: '3-Digit Add/Sub',
+    nameHe: 'חיבור וחיסור תלת-ספרתי',
+    operationType: OPERATION_TYPES.INTEGER_ARITHMETIC,
+    operators: ['+', '-'],
+    numberRange: { min: 100, max: 999 },
+    ageTarget: '8',
+    levelVersion: 2,
+  },
+  {
+    id: 14,
+    grade: 2,
+    name: 'Mixed Operations to 100',
+    nameHe: 'פעולות מעורבות עד 100',
+    operationType: OPERATION_TYPES.INTEGER_ARITHMETIC,
+    operators: ['+', '-', '*', '/'],
+    numberRange: { min: 1, max: 100 },
+    ageTarget: '8',
+    levelVersion: 2,
+  },
+  // ── Grade 3 (6 levels) ─────────────────────────────────────────────────────
+  {
+    id: 15,
+    grade: 3,
+    name: 'Times Tables ×6,×7',
+    nameHe: 'לוח הכפל ×6, ×7',
+    operationType: OPERATION_TYPES.INTEGER_ARITHMETIC,
+    operators: ['*'],
+    numberRange: { min: 1, max: 10 },
+    ageTarget: '9',
+    levelVersion: 2,
+    multipliers: [6, 7],
+  },
+  {
+    id: 16,
+    grade: 3,
+    name: 'Times Tables ×8,×9',
+    nameHe: 'לוח הכפל ×8, ×9',
+    operationType: OPERATION_TYPES.INTEGER_ARITHMETIC,
+    operators: ['*'],
+    numberRange: { min: 1, max: 10 },
+    ageTarget: '9',
+    levelVersion: 2,
+    multipliers: [8, 9],
+  },
+  {
+    id: 17,
+    grade: 3,
+    name: '4-Digit Add/Sub',
+    nameHe: 'חיבור וחיסור ארבע-ספרתי',
+    operationType: OPERATION_TYPES.INTEGER_ARITHMETIC,
+    operators: ['+', '-'],
+    numberRange: { min: 1000, max: 9999 },
+    ageTarget: '9',
+    levelVersion: 2,
+  },
+  {
+    id: 18,
+    grade: 3,
+    name: 'Mixed All Ops (to 100)',
+    nameHe: 'כל הפעולות עד 100',
+    operationType: OPERATION_TYPES.INTEGER_ARITHMETIC,
+    operators: ['+', '-', '*', '/'],
+    numberRange: { min: 1, max: 100 },
+    ageTarget: '9',
+    levelVersion: 2,
+  },
+  {
+    id: 19,
+    grade: 3,
+    name: 'Division Mastery',
+    nameHe: 'שליטה בחילוק',
+    operationType: OPERATION_TYPES.INTEGER_ARITHMETIC,
+    operators: ['/'],
+    numberRange: { min: 1, max: 100 },
+    ageTarget: '9',
+    levelVersion: 2,
+    divisors: [2, 3, 4, 5, 6, 7, 8, 9, 10],
+  },
+  {
+    id: 20,
+    grade: 3,
+    name: 'Mixed All Ops (to 1000)',
+    nameHe: 'כל הפעולות עד 1000',
+    operationType: OPERATION_TYPES.INTEGER_ARITHMETIC,
+    operators: ['+', '-', '*', '/'],
+    numberRange: { min: 1, max: 1000 },
+    ageTarget: '9',
+    levelVersion: 2,
+  },
 ]
 
-// NOTE: Level map is PROVISIONAL — update from real school workbooks before launch.
-// See docs/plans/2026-03-07-adaptive-math-trainer-design.md Section 2.
+/** Total number of levels — use this instead of a magic number */
+export const MAX_LEVEL = LEVELS.length
 
+/**
+ * Returns the level config for a given level ID.
+ * Includes backward-compatibility shim: adds minNumber and maxNumber
+ * as aliases for numberRange.min and numberRange.max.
+ *
+ * @param {number} levelId - 1-based level identifier
+ * @returns {Object} Level configuration with minNumber/maxNumber shim fields
+ * @throws {Error} If levelId is out of range
+ */
 export function getLevelConfig(levelId) {
   if (levelId < 1 || levelId > LEVELS.length) {
     throw new Error(`Invalid level: ${levelId}. Must be 1-${LEVELS.length}`)
   }
-  return LEVELS[levelId - 1]
+  const level = LEVELS[levelId - 1]
+  return {
+    ...level,
+    minNumber: level.numberRange.min,
+    maxNumber: level.numberRange.max,
+  }
+}
+
+/**
+ * Returns all levels for a given grade.
+ *
+ * @param {number} grade - Grade number
+ * @returns {Object[]} Array of level objects for that grade
+ */
+export function getLevelsByGrade(grade) {
+  return LEVELS.filter((level) => level.grade === grade)
+}
+
+/**
+ * Returns the grade number for a given level ID.
+ *
+ * @param {number} levelId - 1-based level identifier
+ * @returns {number} Grade number
+ */
+export function getGradeForLevel(levelId) {
+  return getLevelConfig(levelId).grade
 }
 
 export default LEVELS

--- a/src/config/levels.test.js
+++ b/src/config/levels.test.js
@@ -1,31 +1,164 @@
 import { describe, it, expect } from 'vitest'
-import { LEVELS, getLevelConfig } from './levels'
+import {
+  LEVELS,
+  OPERATION_TYPES,
+  GRADES,
+  MAX_LEVEL,
+  getLevelConfig,
+  getLevelsByGrade,
+  getGradeForLevel,
+} from './levels'
 
 describe('Level Configuration', () => {
-  it('LEVELS has 13 entries', () => {
-    expect(LEVELS).toHaveLength(13)
+  it('LEVELS array has exactly 20 entries', () => {
+    expect(LEVELS).toHaveLength(20)
+  })
+
+  it('MAX_LEVEL equals 20', () => {
+    expect(MAX_LEVEL).toBe(20)
+  })
+
+  it('all level IDs are sequential 1-20', () => {
+    LEVELS.forEach((level, i) => {
+      expect(level.id).toBe(i + 1)
+    })
   })
 
   it('each level has required fields', () => {
     LEVELS.forEach((level, i) => {
-      expect(level).toHaveProperty('id', i + 1)
-      expect(level).toHaveProperty('name')
-      expect(level).toHaveProperty('operators')
-      expect(level).toHaveProperty('minNumber')
-      expect(level).toHaveProperty('maxNumber')
-      expect(level).toHaveProperty('ageTarget')
+      expect(level, `level ${i + 1}`).toHaveProperty('id')
+      expect(level, `level ${i + 1}`).toHaveProperty('grade')
+      expect(level, `level ${i + 1}`).toHaveProperty('name')
+      expect(level, `level ${i + 1}`).toHaveProperty('nameHe')
+      expect(level, `level ${i + 1}`).toHaveProperty('operationType')
+      expect(level, `level ${i + 1}`).toHaveProperty('operators')
+      expect(level, `level ${i + 1}`).toHaveProperty('numberRange')
+      expect(level, `level ${i + 1}`).toHaveProperty('ageTarget')
+      expect(level, `level ${i + 1}`).toHaveProperty('levelVersion')
     })
   })
 
-  it('getLevelConfig returns correct level', () => {
-    expect(getLevelConfig(1).operators).toEqual(['+'])
-    expect(getLevelConfig(1).maxNumber).toBe(5)
-    expect(getLevelConfig(4).operators).toEqual(['+', '-'])
-    expect(getLevelConfig(13).operators).toEqual(['+', '-', '*', '/'])
+  it('all levels have operationType === integer-arithmetic', () => {
+    LEVELS.forEach((level) => {
+      expect(level.operationType).toBe(OPERATION_TYPES.INTEGER_ARITHMETIC)
+    })
   })
 
-  it('getLevelConfig throws for invalid level', () => {
-    expect(() => getLevelConfig(0)).toThrow()
-    expect(() => getLevelConfig(14)).toThrow()
+  it('all levels have levelVersion === 2', () => {
+    LEVELS.forEach((level) => {
+      expect(level.levelVersion).toBe(2)
+    })
+  })
+
+  it('Grade 1 levels have grade === 1', () => {
+    const grade1 = LEVELS.filter((l) => l.id >= 1 && l.id <= 8)
+    grade1.forEach((level) => expect(level.grade).toBe(1))
+  })
+
+  it('Grade 2 levels have grade === 2', () => {
+    const grade2 = LEVELS.filter((l) => l.id >= 9 && l.id <= 14)
+    grade2.forEach((level) => expect(level.grade).toBe(2))
+  })
+
+  it('Grade 3 levels have grade === 3', () => {
+    const grade3 = LEVELS.filter((l) => l.id >= 15 && l.id <= 20)
+    grade3.forEach((level) => expect(level.grade).toBe(3))
+  })
+
+  describe('getLevelConfig', () => {
+    it('returns first level for id 1', () => {
+      const level = getLevelConfig(1)
+      expect(level.id).toBe(1)
+      expect(level.name).toBe('Add within 5')
+    })
+
+    it('returns last level for id 20', () => {
+      const level = getLevelConfig(20)
+      expect(level.id).toBe(20)
+      expect(level.name).toBe('Mixed All Ops (to 1000)')
+    })
+
+    it('throws for id 0', () => {
+      expect(() => getLevelConfig(0)).toThrow()
+    })
+
+    it('throws for id 21', () => {
+      expect(() => getLevelConfig(21)).toThrow()
+    })
+
+    it('returns minNumber/maxNumber shim fields', () => {
+      const level = getLevelConfig(1)
+      expect(level.minNumber).toBe(level.numberRange.min)
+      expect(level.maxNumber).toBe(level.numberRange.max)
+    })
+
+    it('shim values match numberRange for level 8 (tens)', () => {
+      const level = getLevelConfig(8)
+      expect(level.minNumber).toBe(10)
+      expect(level.maxNumber).toBe(100)
+    })
+
+    it('shim values match numberRange for level 20', () => {
+      const level = getLevelConfig(20)
+      expect(level.minNumber).toBe(1)
+      expect(level.maxNumber).toBe(1000)
+    })
+  })
+
+  describe('getLevelsByGrade', () => {
+    it('returns 8 levels for grade 1', () => {
+      expect(getLevelsByGrade(1)).toHaveLength(8)
+    })
+
+    it('returns 6 levels for grade 2', () => {
+      expect(getLevelsByGrade(2)).toHaveLength(6)
+    })
+
+    it('returns 6 levels for grade 3', () => {
+      expect(getLevelsByGrade(3)).toHaveLength(6)
+    })
+
+    it('returns empty array for unknown grade', () => {
+      expect(getLevelsByGrade(99)).toEqual([])
+    })
+  })
+
+  describe('getGradeForLevel', () => {
+    it('returns 1 for level 1', () => {
+      expect(getGradeForLevel(1)).toBe(1)
+    })
+
+    it('returns 2 for level 10', () => {
+      expect(getGradeForLevel(10)).toBe(2)
+    })
+
+    it('returns 3 for level 15', () => {
+      expect(getGradeForLevel(15)).toBe(3)
+    })
+
+    it('returns 3 for level 20', () => {
+      expect(getGradeForLevel(20)).toBe(3)
+    })
+  })
+
+  describe('OPERATION_TYPES', () => {
+    it('is frozen', () => {
+      expect(Object.isFrozen(OPERATION_TYPES)).toBe(true)
+    })
+
+    it('has INTEGER_ARITHMETIC key', () => {
+      expect(OPERATION_TYPES.INTEGER_ARITHMETIC).toBe('integer-arithmetic')
+    })
+  })
+
+  describe('GRADES', () => {
+    it('is frozen', () => {
+      expect(Object.isFrozen(GRADES)).toBe(true)
+    })
+
+    it('has GRADE_1 through GRADE_6', () => {
+      expect(GRADES.GRADE_1).toBe(1)
+      expect(GRADES.GRADE_6).toBe(6)
+    })
   })
 })

--- a/src/utils/mathProblems.test.js
+++ b/src/utils/mathProblems.test.js
@@ -40,14 +40,14 @@ describe('mathProblems', () => {
   });
 
   describe('backward compatibility - no args', () => {
-    it('generateProblem() with no args uses level 2 defaults (operators +/-, range 1-10)', () => {
+    it('generateProblem() with no args uses level 2 defaults (operator -, range 0-5)', () => {
       for (let i = 0; i < 50; i++) {
         const problem = generateProblem();
-        expect(['+', '-']).toContain(problem.operator);
-        expect(problem.num1).toBeGreaterThanOrEqual(1);
-        expect(problem.num1).toBeLessThanOrEqual(10);
-        expect(problem.num2).toBeGreaterThanOrEqual(1);
-        expect(problem.num2).toBeLessThanOrEqual(10);
+        expect(problem.operator).toBe('-');
+        expect(problem.num1).toBeGreaterThanOrEqual(0);
+        expect(problem.num1).toBeLessThanOrEqual(5);
+        expect(problem.num2).toBeGreaterThanOrEqual(0);
+        expect(problem.num2).toBeLessThanOrEqual(5);
       }
     });
 
@@ -64,20 +64,20 @@ describe('mathProblems', () => {
 
   describe('level config usage', () => {
     it('passes level config through to generate correct operator types', () => {
-      const level1 = getLevelConfig(1); // addition only, 1-5
+      const level1 = getLevelConfig(1); // addition only, 0-5
       for (let i = 0; i < 50; i++) {
         const problem = generateProblem(level1);
         expect(problem.operator).toBe('+');
-        expect(problem.num1).toBeGreaterThanOrEqual(1);
+        expect(problem.num1).toBeGreaterThanOrEqual(0);
         expect(problem.num1).toBeLessThanOrEqual(5);
-        expect(problem.num2).toBeGreaterThanOrEqual(1);
+        expect(problem.num2).toBeGreaterThanOrEqual(0);
         expect(problem.num2).toBeLessThanOrEqual(5);
       }
     });
 
     it('generateProblems passes levelConfig through', () => {
-      const level3 = getLevelConfig(3); // subtraction only
-      const problems = generateProblems(20, level3);
+      const level2 = getLevelConfig(2); // subtraction only, 0-5
+      const problems = generateProblems(20, level2);
       problems.forEach(p => {
         expect(p.operator).toBe('-');
       });
@@ -97,12 +97,12 @@ describe('mathProblems', () => {
       }
     });
 
-    it('uses default multipliers when none specified (level 13)', () => {
-      const level13 = getLevelConfig(13);
+    it('uses default multipliers when none specified (level 14)', () => {
+      const level14 = getLevelConfig(14);
       const defaultMultipliers = [2, 3, 4, 5, 6, 7, 8, 9, 10];
       let sawMultiply = false;
       for (let i = 0; i < 200; i++) {
-        const problem = generateProblem(level13);
+        const problem = generateProblem(level14);
         if (problem.operator === '*') {
           sawMultiply = true;
           expect(defaultMultipliers).toContain(problem.num1);
@@ -184,12 +184,12 @@ describe('mathProblems', () => {
     });
   });
 
-  describe('mixed operators (level 13)', () => {
+  describe('mixed operators (level 14)', () => {
     it('produces all 4 operator types across many iterations', () => {
-      const level13 = getLevelConfig(13);
+      const level14 = getLevelConfig(14);
       const seenOps = new Set();
       for (let i = 0; i < 200; i++) {
-        const problem = generateProblem(level13);
+        const problem = generateProblem(level14);
         seenOps.add(problem.operator);
         // Validate each problem regardless of operator
         expect(problem).toHaveProperty('num1');
@@ -217,17 +217,17 @@ describe('mathProblems', () => {
 
   describe('property tests - operator invariants', () => {
     it('addition: correctAnswer always equals num1 + num2', () => {
-      const level2 = getLevelConfig(2);
+      const level3 = getLevelConfig(3); // addition only, 0-10
       for (let i = 0; i < 100; i++) {
-        const p = generateProblem(level2);
+        const p = generateProblem(level3);
         expect(p.correctAnswer).toBe(p.num1 + p.num2);
       }
     });
 
     it('subtraction: correctAnswer always equals num1 - num2', () => {
-      const level3 = getLevelConfig(3);
+      const level2 = getLevelConfig(2); // subtraction only, 0-5
       for (let i = 0; i < 100; i++) {
-        const p = generateProblem(level3);
+        const p = generateProblem(level2);
         expect(p.correctAnswer).toBe(p.num1 - p.num2);
       }
     });


### PR DESCRIPTION
Closes #145

## Summary

Implements the level schema and data definitions for the Shvilim curriculum (grades 1-3).

### What was built

- **20 levels defined** — grades 1-3 aligned to Israeli Shvilim curriculum
- **`OPERATION_TYPES` + `GRADES` enums** — frozen constants for type safety
- **`getLevelConfig(levelNumber)`** — primary lookup with backward-compat shim exposing `minNumber`/`maxNumber` on returned config
- **`getLevelsByGrade(grade)`** — returns all levels for a given grade
- **`getGradeForLevel(levelNumber)`** — reverse lookup: level number → grade
- **`MAX_LEVEL` now dynamic** — equals `LEVELS.length` (20), no magic number
- **Bilingual level names** — Hebrew + English names for all 20 levels

### Test coverage

- 28 new unit tests added
- 907 total tests passing
- Zero lint errors

## Checklist
- [x] Tests passing (907/907, 0 failures)
- [x] Lint clean (0 errors, 0 warnings)
- [x] Code review (syntax + security)
- [x] CI green