### PR TITLE
#146: Profile Migration (old levels 1-13 → new IDs)

### DIFF
--- a/src/context/ProfileContext.jsx
+++ b/src/context/ProfileContext.jsx
@@ -26,6 +26,7 @@ import {
   verifyPin,
   MAX_PROFILES,
 } from '../utils/profiles'
+import { needsMigration, migrateProfile } from '../utils/migration'
 import {
   SESSION_KEY,
   Actions,
@@ -53,7 +54,16 @@ export default function ProfileProvider({ children }) {
 
   // ── Bootstrap: load profiles + restore session ────────────────────────
   useEffect(() => {
-    const profiles = getProfiles()
+    const raw = getProfiles()
+
+    // Transparently migrate any profiles created before the curriculum restructure
+    const profiles = raw.map((p) => {
+      if (!needsMigration(p)) return p
+      const migrated = migrateProfile(p)
+      updateProfileStorage(p.id, { currentLevel: migrated.currentLevel, levelVersion: migrated.levelVersion })
+      return migrated
+    })
+
     dispatch({ type: Actions.SET_PROFILES, payload: profiles })
 
     const storedId = sessionStorage.getItem(SESSION_KEY)

--- a/src/utils/migration.js
+++ b/src/utils/migration.js
@@ -1,0 +1,59 @@
+/**
+ * Profile migration utilities for curriculum restructure.
+ *
+ * When the level configuration was restructured, some old level IDs (1-13)
+ * were remapped to new IDs. Profiles stored with the old IDs need a one-time
+ * migration so that a player's progress maps to the correct new level.
+ *
+ * levelVersion field:
+ *   missing / < 2  →  needs migration (was created before curriculum restructure)
+ *   2              →  already migrated (no action needed)
+ */
+
+/** Maps old level IDs (1-13) to new level IDs */
+const OLD_TO_NEW_MAP = {
+  1: 1, 2: 2, 3: 3, 4: 4, 5: 5, 6: 6, 7: 7, 8: 8,
+  9: 13, 10: 10, 11: 11, 12: 12, 13: 18,
+}
+
+/**
+ * Maps a single old level ID to its new ID.
+ * Falls back to 1 for any unknown or invalid input.
+ *
+ * @param {number} oldLevel
+ * @returns {number}
+ */
+export function migrateLevel(oldLevel) {
+  return OLD_TO_NEW_MAP[oldLevel] ?? 1
+}
+
+/**
+ * Returns true when the given profile was created before the curriculum
+ * restructure and its currentLevel has not yet been remapped.
+ *
+ * @param {Object} profile
+ * @returns {boolean}
+ */
+export function needsMigration(profile) {
+  return !profile.levelVersion || profile.levelVersion < 2
+}
+
+/**
+ * Returns a migrated copy of the profile with currentLevel remapped to the
+ * new ID and levelVersion set to 2.  If the profile does not need migration
+ * the original object is returned unchanged (referential equality preserved).
+ *
+ * This function is idempotent: calling it twice produces the same result as
+ * calling it once.
+ *
+ * @param {Object} profile
+ * @returns {Object}
+ */
+export function migrateProfile(profile) {
+  if (!needsMigration(profile)) return profile
+  return {
+    ...profile,
+    currentLevel: migrateLevel(profile.currentLevel),
+    levelVersion: 2,
+  }
+}

--- a/src/utils/migration.test.js
+++ b/src/utils/migration.test.js
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest'
+import { migrateLevel, needsMigration, migrateProfile } from './migration'
+
+describe('migrateLevel', () => {
+  it('returns 1 for level 1 (identity mapping)', () => {
+    expect(migrateLevel(1)).toBe(1)
+  })
+
+  it('returns 13 for level 9 (non-trivial mapping)', () => {
+    expect(migrateLevel(9)).toBe(13)
+  })
+
+  it('returns 18 for level 13 (max old level)', () => {
+    expect(migrateLevel(13)).toBe(18)
+  })
+
+  it('returns 1 for level 0 (fallback for invalid)', () => {
+    expect(migrateLevel(0)).toBe(1)
+  })
+
+  it('returns 1 for level 14 (fallback for out-of-range)', () => {
+    expect(migrateLevel(14)).toBe(1)
+  })
+
+  it('returns 1 for undefined (fallback for missing)', () => {
+    expect(migrateLevel(undefined)).toBe(1)
+  })
+})
+
+describe('needsMigration', () => {
+  it('returns true when profile has no levelVersion', () => {
+    expect(needsMigration({ currentLevel: 5 })).toBe(true)
+  })
+
+  it('returns true when profile has levelVersion 1 (old version)', () => {
+    expect(needsMigration({ currentLevel: 5, levelVersion: 1 })).toBe(true)
+  })
+
+  it('returns false when profile has levelVersion 2 (already migrated)', () => {
+    expect(needsMigration({ currentLevel: 5, levelVersion: 2 })).toBe(false)
+  })
+})
+
+describe('migrateProfile', () => {
+  it('migrates currentLevel and sets levelVersion 2', () => {
+    const result = migrateProfile({ currentLevel: 13, score: 100 })
+    expect(result).toEqual({ currentLevel: 18, score: 100, levelVersion: 2 })
+  })
+
+  it('is a no-op when profile already has levelVersion 2', () => {
+    const profile = { currentLevel: 5, levelVersion: 2, score: 100 }
+    expect(migrateProfile(profile)).toBe(profile)
+  })
+
+  it('is idempotent: migrateProfile(migrateProfile(profile)) equals migrateProfile(profile)', () => {
+    const profile = { currentLevel: 9, score: 50 }
+    const once = migrateProfile(profile)
+    const twice = migrateProfile(once)
+    expect(twice).toEqual(once)
+  })
+})


### PR DESCRIPTION
Part of #140. Implements migration function for old level IDs to new curriculum IDs.