### PR TITLE
#140.6: Remove Shim + Final Cleanup

### DIFF
--- a/src/config/levels.js
+++ b/src/config/levels.js
@@ -254,23 +254,16 @@ export const MAX_LEVEL = LEVELS.length
 
 /**
  * Returns the level config for a given level ID.
- * Includes backward-compatibility shim: adds minNumber and maxNumber
- * as aliases for numberRange.min and numberRange.max.
  *
  * @param {number} levelId - 1-based level identifier
- * @returns {Object} Level configuration with minNumber/maxNumber shim fields
+ * @returns {Object} Level configuration object with numberRange: { min, max }
  * @throws {Error} If levelId is out of range
  */
 export function getLevelConfig(levelId) {
   if (levelId < 1 || levelId > LEVELS.length) {
     throw new Error(`Invalid level: ${levelId}. Must be 1-${LEVELS.length}`)
   }
-  const level = LEVELS[levelId - 1]
-  return {
-    ...level,
-    minNumber: level.numberRange.min,
-    maxNumber: level.numberRange.max,
-  }
+  return LEVELS[levelId - 1]
 }
 
 /**

--- a/src/config/levels.test.js
+++ b/src/config/levels.test.js
@@ -86,22 +86,22 @@ describe('Level Configuration', () => {
       expect(() => getLevelConfig(21)).toThrow()
     })
 
-    it('returns minNumber/maxNumber shim fields', () => {
+    it('does not include minNumber/maxNumber shim fields', () => {
       const level = getLevelConfig(1)
-      expect(level.minNumber).toBe(level.numberRange.min)
-      expect(level.maxNumber).toBe(level.numberRange.max)
+      expect(level.minNumber).toBeUndefined()
+      expect(level.maxNumber).toBeUndefined()
     })
 
-    it('shim values match numberRange for level 8 (tens)', () => {
+    it('returns native numberRange for level 8 (tens)', () => {
       const level = getLevelConfig(8)
-      expect(level.minNumber).toBe(10)
-      expect(level.maxNumber).toBe(100)
+      expect(level.numberRange.min).toBe(10)
+      expect(level.numberRange.max).toBe(100)
     })
 
-    it('shim values match numberRange for level 20', () => {
+    it('returns native numberRange for level 20', () => {
       const level = getLevelConfig(20)
-      expect(level.minNumber).toBe(1)
-      expect(level.maxNumber).toBe(1000)
+      expect(level.numberRange.min).toBe(1)
+      expect(level.numberRange.max).toBe(1000)
     })
   })
 

--- a/src/hooks/useGameState.test.js
+++ b/src/hooks/useGameState.test.js
@@ -22,15 +22,13 @@ vi.mock('../config/levels', () => ({
     id: i + 1,
     name: `Level ${i + 1}`,
     operators: ['+'],
-    minNumber: 1,
-    maxNumber: 10,
+    numberRange: { min: 1, max: 10 },
   })),
   getLevelConfig: vi.fn((id) => ({
     id: id ?? 1,
     name: `Level ${id ?? 1}`,
     operators: ['+'],
-    minNumber: 1,
-    maxNumber: 10,
+    numberRange: { min: 1, max: 10 },
   })),
 }))
 

--- a/src/utils/strategies.test.js
+++ b/src/utils/strategies.test.js
@@ -940,13 +940,13 @@ describe('strategies', () => {
         if (!config.operators.includes('+')) continue;
         for (let i = 0; i < 50; i++) {
           const num1 = config.multiplesOf
-            ? Math.ceil(config.minNumber / config.multiplesOf) * config.multiplesOf
-              + Math.floor(Math.random() * ((config.maxNumber - config.minNumber) / config.multiplesOf)) * config.multiplesOf
-            : getRandomInt(config.minNumber, config.maxNumber);
+            ? Math.ceil(config.numberRange.min / config.multiplesOf) * config.multiplesOf
+              + Math.floor(Math.random() * ((config.numberRange.max - config.numberRange.min) / config.multiplesOf)) * config.multiplesOf
+            : getRandomInt(config.numberRange.min, config.numberRange.max);
           const num2 = config.multiplesOf
-            ? Math.ceil(config.minNumber / config.multiplesOf) * config.multiplesOf
-              + Math.floor(Math.random() * ((config.maxNumber - config.minNumber) / config.multiplesOf)) * config.multiplesOf
-            : getRandomInt(config.minNumber, config.maxNumber);
+            ? Math.ceil(config.numberRange.min / config.multiplesOf) * config.multiplesOf
+              + Math.floor(Math.random() * ((config.numberRange.max - config.numberRange.min) / config.multiplesOf)) * config.multiplesOf
+            : getRandomInt(config.numberRange.min, config.numberRange.max);
           const result = getStrategies(num1, num2, '+');
           expect(result.length).toBeGreaterThanOrEqual(1);
           count++;
@@ -962,13 +962,13 @@ describe('strategies', () => {
         if (!config.operators.includes('-')) continue;
         for (let i = 0; i < 50; i++) {
           let num1 = config.multiplesOf
-            ? Math.ceil(config.minNumber / config.multiplesOf) * config.multiplesOf
-              + Math.floor(Math.random() * ((config.maxNumber - config.minNumber) / config.multiplesOf)) * config.multiplesOf
-            : getRandomInt(config.minNumber, config.maxNumber);
+            ? Math.ceil(config.numberRange.min / config.multiplesOf) * config.multiplesOf
+              + Math.floor(Math.random() * ((config.numberRange.max - config.numberRange.min) / config.multiplesOf)) * config.multiplesOf
+            : getRandomInt(config.numberRange.min, config.numberRange.max);
           let num2 = config.multiplesOf
-            ? Math.ceil(config.minNumber / config.multiplesOf) * config.multiplesOf
-              + Math.floor(Math.random() * ((num1 - config.minNumber) / config.multiplesOf)) * config.multiplesOf
-            : getRandomInt(config.minNumber, num1);
+            ? Math.ceil(config.numberRange.min / config.multiplesOf) * config.multiplesOf
+              + Math.floor(Math.random() * ((num1 - config.numberRange.min) / config.multiplesOf)) * config.multiplesOf
+            : getRandomInt(config.numberRange.min, num1);
           // Ensure num1 >= num2
           if (num1 < num2) [num1, num2] = [num2, num1];
           const result = getStrategies(num1, num2, '-');


### PR DESCRIPTION
Closes #150

## Summary

Remove the backward-compat `minNumber`/`maxNumber` shim from `getLevelConfig()`, verify zero references to the old field names across the codebase, and ensure the full test suite stays green.

## Changes

- Remove `minNumber`/`maxNumber` shim from `getLevelConfig()` in `src/config/levels.js`
- Audit entire codebase for any remaining references to old field names (`minNumber`, `maxNumber`) and remove/update them
- Confirm all existing tests pass with no regressions

## Checklist

- [ ] `minNumber`/`maxNumber` shim removed from `getLevelConfig()`
- [ ] Zero references to old field names in codebase
- [ ] Full test suite green
- [ ] Lint clean